### PR TITLE
Changed interactation with IODDmodule, some parsing bugfixes

### DIFF
--- a/CSK_Module_MultiIOLinkSMI/pages/pages/CSK_Module_MultiIOLinkSMI/CSK_Module_MultiIOLinkSMI.html
+++ b/CSK_Module_MultiIOLinkSMI/pages/pages/CSK_Module_MultiIOLinkSMI/CSK_Module_MultiIOLinkSMI.html
@@ -937,15 +937,13 @@
                                                                                 style="align-items: stretch">
                                                                                 <curie-table id="DT_ProcessDataIn"
                                                                                     selectable title="Process data">
-                                                                                    <curie-table-column id="read_colPD1"
-                                                                                        header="Subindex">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colPD2"
-                                                                                        header="Name">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colPD3"
-                                                                                        header="Data type, Range, Single value description">
-                                                                                    </curie-table-column>
+												<curie-table-column id="readIOLink_colPD1" header="Subindex">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colPD2" header="Name">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colPD3"
+													header="Data type, Range, Single value description">
+												</curie-table-column>
                                                                                     <crown-binding event="row-selected"
                                                                                         name="CSK_MultiIOLinkSMI/processDataInRowSelectedCSKIODDInterpreter"
                                                                                         path="param/args/rowData"
@@ -964,27 +962,21 @@
                                                                                 style="align-items: stretch">
                                                                                 <curie-table id="DT_ReadParameters"
                                                                                     selectable title="Read parameters">
-                                                                                    <curie-table-column id="read_colSD1"
-                                                                                        header="Index">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD2"
-                                                                                        header="Subindex">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD3"
-                                                                                        header="ID">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD4"
-                                                                                        header="Name">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD5"
-                                                                                        header="Data type, Range, Single value description">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD6"
-                                                                                        header="Read/Write">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column id="read_colSD7"
-                                                                                        header="Description">
-                                                                                    </curie-table-column>
+												<curie-table-column id="readIOLink_colSD1" header="Index">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD2" header="Subindex">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD3" header="ID">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD4" header="Name">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD5"
+													header="Data type, Range, Single value description">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD6" header="Read/Write">
+												</curie-table-column>
+												<curie-table-column id="readIOLink_colSD7" header="Description">
+												</curie-table-column>
                                                                                     <crown-binding event="row-selected"
                                                                                         name="CSK_MultiIOLinkSMI/readParameterRowSelectedCSKIODDInterpreter"
                                                                                         path="param/args/rowData"
@@ -1349,17 +1341,13 @@
                                                                                 <curie-table id="DT_ProcessDataOut"
                                                                                     selectable
                                                                                     title="Structure of Process Data Out">
-                                                                                    <curie-table-column
-                                                                                        id="write_colPD1"
-                                                                                        header="Subindex">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colPD2" header="Name">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colPD3"
-                                                                                        header="Data type, Range, Single value description">
-                                                                                    </curie-table-column>
+												<curie-table-column id="writeIOLink_colPD1" header="Subindex">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colPD2" header="Name">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colPD3"
+													header="Data type, Range, Single value description">
+												</curie-table-column>
                                                                                     <crown-on property="data"
                                                                                         crown-event="CSK_MultiIOLinkSMI/OnNewProcessDataOutTableContentCSKIODDInterpreter">
                                                                                     </crown-on>
@@ -1378,32 +1366,21 @@
                                                                                 style="align-items: stretch">
                                                                                 <curie-table id="DT_WriteParameter"
                                                                                     selectable title="Write Parameters">
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD1"
-                                                                                        header="Index">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD2"
-                                                                                        header="Subindex">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD3" header="ID">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD4" header="Name">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD5"
-                                                                                        header="Data type, Range, Single value description">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD6"
-                                                                                        header="Read/Write">
-                                                                                    </curie-table-column>
-                                                                                    <curie-table-column
-                                                                                        id="write_colSD7"
-                                                                                        header="Description">
-                                                                                    </curie-table-column>
+												<curie-table-column id="writeIOLink_colSD1" header="Index">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD2" header="Subindex">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD3" header="ID">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD4" header="Name">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD5"
+													header="Data type, Range, Single value description">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD6" header="Read/Write">
+												</curie-table-column>
+												<curie-table-column id="writeIOLink_colSD7" header="Description">
+												</curie-table-column>
                                                                                     <crown-on property="data"
                                                                                         crown-event="CSK_MultiIOLinkSMI/OnNewWriteParametersTableContentCSKIODDInterpreter">
                                                                                     </crown-on>

--- a/CSK_Module_MultiIOLinkSMI/project.mf.xml
+++ b/CSK_Module_MultiIOLinkSMI/project.mf.xml
@@ -422,20 +422,23 @@ NUM will be replaced by the number of instance (e.g. "OnNewValueToForward1"). +<
                 </event>
                 <event name="OnNewPortInformation">
                     <trait>released</trait>
-                    <param desc="" multiplicity="1" name="instanceId" type="int"/>
-                    <param desc="" multiplicity="1" name="portNumber" type="string"/>
-                    <param desc="" multiplicity="1" name="portStatus" type="string"/>
-                    <param desc="" multiplicity="?" name="jsonDeviceIdentification" type="string"/>
-                    <param desc="" multiplicity="?" name="ioddName" type="string"/>
-                    <param desc="" multiplicity="?" name="jsonNewDeviceIdentification" type="string"/>
+                    <desc>Event triggerd when port status has changed which might mean that the IOLink device was connected/disconnected or another devices was connected. </desc>
+                    <param desc="Instance ID." multiplicity="1" name="instanceId" type="int"/>
+                    <param desc="Port name like S1, S2 ..." multiplicity="1" name="portNumber" type="string"/>
+                    <param desc="New port status." multiplicity="1" name="portStatus" type="string"/>
+                    <param desc="JSON object containing the saved device identification for this port." multiplicity="?" name="jsonDeviceIdentification" type="string"/>
+                    <param desc="IODD name of an IODD object used in CSK_Module_IODDInterpreter for this instance." multiplicity="?" name="ioddName" type="string"/>
+                    <param desc="Optional JSON object with the device identification of the connected device if its ID does not match the saved one for this instance." multiplicity="?" name="jsonNewDeviceIdentification" type="string"/>
                 </event>
                 <event name="OnNewDeviceId">
                     <trait>released</trait>
-                    <param desc="" multiplicity="1" name="deviceId" type="string"/>
+                    <desc>Event to show the device ID of the device.</desc>
+                    <param desc="Device ID." multiplicity="1" name="deviceId" type="string"/>
                 </event>
                 <event name="OnNewNewDeviceDeviceId">
                     <trait>released</trait>
-                    <param desc="" multiplicity="1" name="deviceId" type="string"/>
+                    <desc>Event to show the device ID of new discovered device.</desc>
+                    <param desc="Device ID." multiplicity="1" name="deviceId" type="string"/>
                 </event>
                 <event name="readMessagePortMessageName">
                     <trait>released</trait>
@@ -957,30 +960,36 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").
                     <desc>Function to reset main configuration of module.</desc>
                 </function>
                 <function name="getInstancePortMap">
-                    <desc/>
-                    <return desc="" multiplicity="1" name="jsonInstancePortMap" type="string"/>
+                    <desc>Function to get a map of what ports are controlled by instances.</desc>
+                    <return desc="JSON object with the map." multiplicity="1" name="jsonInstancePortMap" type="string"/>
                 </function>
                 <function name="getDeviceConfig">
-                    <desc/>
-                    <return desc="" multiplicity="1" name="jsonCopiedDeviceConfig" type="string"/>
+                    <desc>Function to get the device configuration that can be use to copy it and apply for another device if DeviceId and VendorId are matched.</desc>
+                    <return desc="JSON object with device configuration" multiplicity="1" name="jsonCopiedDeviceConfig" type="string"/>
                 </function>
                 <function name="pasteReadDataMessage">
                     <trait>released</trait>
-                    <return desc="" multiplicity="?" name="processDataTableContent" type="string"/>
-                    <return desc="" multiplicity="?" name="parameterTableContent" type="string"/>
-                    <return desc="" multiplicity="?" name="jsonTemplate" type="string"/>
+                    <desc>Function to paste the copied read data message configuration. See copyReadDataMessage</desc>
+                    <return desc="JSON object with selected process data information." multiplicity="?" name="processDataTableContent" type="string"/>
+                    <return desc="JSON object with selected parameters information." multiplicity="?" name="parameterTableContent" type="string"/>
+                    <return desc="New JSON template of the read message." multiplicity="?" name="jsonTemplate" type="string"/>
                 </function>
                 <function name="copyReadDataMessage">
                     <trait>released</trait>
+                    <desc>Function to copy the selected read data message. It can be pasted in another instance (IOLink device) if the device is same. Pasting is done via 
+pasteReadDataMessage.</desc>
                 </function>
                 <function name="copyWriteDataMessage">
                     <trait>released</trait>
+                    <desc>Function to copy the selected write data message. It can be pasted in another instance (IOLink device) if the device is same. Pasting is done via 
+pasteWriteDataMessage.</desc>
                 </function>
                 <function name="pasteWriteDataMessage">
                     <trait>released</trait>
-                    <return desc="" multiplicity="?" name="processDataTableContent" type="string"/>
-                    <return desc="" multiplicity="?" name="parameterTableContent" type="string"/>
-                    <return desc="" multiplicity="?" name="jsonTemplate" type="string"/>
+                    <desc>Function to paste the copied write data message configuration. See copyWriteDataMessage</desc>
+                    <return desc="JSON object with selected process data information." multiplicity="?" name="processDataTableContent" type="string"/>
+                    <return desc="JSON object with selected parameters information." multiplicity="?" name="parameterTableContent" type="string"/>
+                    <return desc="New JSON template of the write message." multiplicity="?" name="jsonTemplate" type="string"/>
                 </function>
                 <function name="writeMessagePortMessageName">
                     <trait>released</trait>

--- a/CSK_Module_MultiIOLinkSMI/project.mf.xml
+++ b/CSK_Module_MultiIOLinkSMI/project.mf.xml
@@ -420,6 +420,32 @@ NUM will be replaced by the number of instance (e.g. "OnNewValueToForward1"). +<
                     <desc>Notify version of module.</desc>
                     <param desc="Version" multiplicity="1" name="version" type="string"/>
                 </event>
+                <event name="OnNewPortInformation">
+                    <trait>released</trait>
+                    <param desc="" multiplicity="1" name="instanceId" type="int"/>
+                    <param desc="" multiplicity="1" name="portNumber" type="string"/>
+                    <param desc="" multiplicity="1" name="portStatus" type="string"/>
+                    <param desc="" multiplicity="?" name="jsonDeviceIdentification" type="string"/>
+                    <param desc="" multiplicity="?" name="ioddName" type="string"/>
+                    <param desc="" multiplicity="?" name="jsonNewDeviceIdentification" type="string"/>
+                </event>
+                <event name="OnNewDeviceId">
+                    <trait>released</trait>
+                    <param desc="" multiplicity="1" name="deviceId" type="string"/>
+                </event>
+                <event name="OnNewNewDeviceDeviceId">
+                    <trait>released</trait>
+                    <param desc="" multiplicity="1" name="deviceId" type="string"/>
+                </event>
+                <event name="readMessagePortMessageName">
+                    <trait>released</trait>
+                    <desc>Event that can be used to get the message with data received from IOLink device. Port - sensor port the device is connected to (S1,S2 ...). MessageName - the configured name of the message.</desc>
+                    <param desc="Success of reading data." multiplicity="1" name="success" type="bool"/>
+                    <param desc="Size of the queue calls in the thread responsible for communication with this IOLink device. If the queue builds up, this can lead to memory overflow. That's why the queue is recet to 0 in case there are more than 10 calls." multiplicity="1" name="queueSize" type="int"/>
+                    <param desc="Time in milliseconds spent for getting and parsing the data." multiplicity="1" name="time" type="int"/>
+                    <param desc="JSON object containing the interpreted data." multiplicity="?" name="data" type="string"/>
+                    <param desc="Error message, if any." multiplicity="?" name="detailedErrorMessage" type="string"/>
+                </event>
                 <function name="setParameterName">
                     <desc>Function to set the name of the parameters if saved/loaded via the CSK_PersistentData module.</desc>
                     <param desc="Name of the parameter" multiplicity="1" name="name" type="string"/>
@@ -618,7 +644,8 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
                 <function name="applyNewDeviceIdentification">
                     <trait>released</trait>
                     <desc>Set device identification of a new device.</desc>
-                    <param desc="Json table containing the device identification." multiplicity="1" name="jsonNewDeviceIdentification" type="string"/>
+                    <param desc="" multiplicity="1" name="instance" type="int"/>
+                    <param desc="Json table containing the device identification." multiplicity="?" name="jsonNewDeviceIdentification" type="string"/>
                 </function>
                 <function name="makeDefaultInstance">
                     <desc>Set all instance parameters to default values.</desc>
@@ -928,6 +955,41 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").
                 </function>
                 <function name="resetModule">
                     <desc>Function to reset main configuration of module.</desc>
+                </function>
+                <function name="getInstancePortMap">
+                    <desc/>
+                    <return desc="" multiplicity="1" name="jsonInstancePortMap" type="string"/>
+                </function>
+                <function name="getDeviceConfig">
+                    <desc/>
+                    <return desc="" multiplicity="1" name="jsonCopiedDeviceConfig" type="string"/>
+                </function>
+                <function name="pasteReadDataMessage">
+                    <trait>released</trait>
+                    <return desc="" multiplicity="?" name="processDataTableContent" type="string"/>
+                    <return desc="" multiplicity="?" name="parameterTableContent" type="string"/>
+                    <return desc="" multiplicity="?" name="jsonTemplate" type="string"/>
+                </function>
+                <function name="copyReadDataMessage">
+                    <trait>released</trait>
+                </function>
+                <function name="copyWriteDataMessage">
+                    <trait>released</trait>
+                </function>
+                <function name="pasteWriteDataMessage">
+                    <trait>released</trait>
+                    <return desc="" multiplicity="?" name="processDataTableContent" type="string"/>
+                    <return desc="" multiplicity="?" name="parameterTableContent" type="string"/>
+                    <return desc="" multiplicity="?" name="jsonTemplate" type="string"/>
+                </function>
+                <function name="writeMessagePortMessageName">
+                    <trait>released</trait>
+                    <desc>Function to write the message with to IOLink device. The data must a JSON object that has the same structure as the configured message. Port - sensor port the device is connected to (S1,S2 ...). MessageName - the configured name of the message.</desc>
+                    <param desc="JSON object that has the same structure as the configured message." multiplicity="1" name="data" type="string"/>
+                    <return desc="Success of writing data." multiplicity="1" name="success" type="bool"/>
+                    <return desc="Size of the queue calls in the thread responsible for communication with this IOLink device. If the queue builds up, this can lead to memory overflow. That's why the queue is recet to 0 in case there are more than 10 calls." multiplicity="1" name="queueSize" type="int"/>
+                    <return desc="Time in milliseconds spent for getting and parsing the data." multiplicity="1" name="time" type="int"/>
+                    <return desc="Error message, if any." multiplicity="1" name="errorMessage" type="string"/>
                 </function>
             </serves>
         </crown>

--- a/CSK_Module_MultiIOLinkSMI/scripts/CSK_MultiIOLinkSMI_Processing.lua
+++ b/CSK_Module_MultiIOLinkSMI/scripts/CSK_MultiIOLinkSMI_Processing.lua
@@ -71,28 +71,29 @@ local function readBinaryProcessData()
   if portQualifier == nil then
     return nil
   end
-  --local dataValid = ((portQualifier & 0x80) or (portQualifier & 0xA0)) > 0
-  --if not dataValid then
-  --  _G.logger:warning(nameOfModule..': failed to read process data on port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString)
-  --  return nil
-  --end
+  local dataValid = ((portQualifier & 0x80) or (portQualifier & 0xA0)) > 0
+  if not dataValid then
+    _G.logger:warning(nameOfModule..': failed to read process data on port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString)
+    return nil
+  end
   return string.sub(processData, 3)
 end
 
 --- Read process data with provided info from IODD interpreter (as Lua table) and convert it to a meaningful Lua table
 ---@param dataPointInfo table Table containing process data info from IODD file
+---@return bool success Read success
 ---@return table? convertedResult Interpted read data
 local function readProcessData(dataPointInfo)
   local rawData = readBinaryProcessData()
   if rawData == nil then
-    return nil
+    return false, converter.getFailedReadProcessDataResult(dataPointInfo)
   end
   local success, convertedResult = pcall(converter.getReadProcessDataResult, rawData, dataPointInfo)
   if not success then
     _G.logger:warning(nameOfModule..': failed to convert process data after reading on port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString)
-    return nil
+    return false, converter.getFailedReadProcessDataResult(dataPointInfo)
   end
-  return convertedResult
+  return success, convertedResult
 end
 
 --- Read process data with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table.
@@ -100,8 +101,8 @@ end
 ---@return string? convertedResult JSON table with interpted read data
 local function readProcessDataIODD(jsonDataPointInfo)
   local dataPointInfo = converter.renameDatatype(json.decode(jsonDataPointInfo))
-  local readData = readProcessData(dataPointInfo)
-  if readData == nil then
+  local success, readData = readProcessData(dataPointInfo)
+  if not success then
     return nil
   end
   return json.encode(readData)
@@ -217,18 +218,19 @@ end
 
 --- Read parameter with provided info from IODD interpreter (as Lua table) and convert it to a meaningful Lua table
 ---@param dataPointInfo table Table containing parameter info from IODD file
+---@return bool success Read success
 ---@return table? convertedResult Interpted parameter value
 local function readParameter(dataPointInfo)
   local rawData = readBinaryServiceData(tonumber(dataPointInfo.index), tonumber(dataPointInfo.subindex))
   if rawData == nil then
-    return nil
+    return false, converter.getFailedReadServiceDataResult(dataPointInfo)
   end
   local success, convertedResult = pcall(converter.getReadServiceDataResult, rawData, dataPointInfo)
   if not success then
     _G.logger:warning(nameOfModule..': failed to convert parameter after reading on port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString ..'; datapoint info: ' .. tostring(json.encode(dataPointInfo)))
-    return nil
+    return false, converter.getFailedReadServiceDataResult(dataPointInfo)
   end
-  return convertedResult
+  return true, convertedResult
 end
 
 --Read parameter with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table
@@ -240,8 +242,8 @@ local function readParameterIODD(index, subindex, jsonDataPointInfo)
   local dataPointInfo = converter.renameDatatype(json.decode(jsonDataPointInfo))
   dataPointInfo.index = index
   dataPointInfo.subindex = subindex
-  local readData = readParameter(dataPointInfo)
-  if readData == nil then
+  local success, readData = readParameter(dataPointInfo)
+  if not success then
     return nil
   end
   return json.encode(readData)
@@ -355,24 +357,21 @@ Script.serveFunction('CSK_MultiIOLinkSMI.writeParameterByteArray_' .. multiIOLin
 ---@return bool success Success of reading.
 ---@return string? jsonMessageContent JSON table with received message content.
 local function readIODDMessage(messageName)
+  if not ioddReadMessages[messageName] or not ioddReadMessages[messageName].dataInfo then
+    return false, "No data selected for read"
+  end
   local success = true
   local messageContent = {}
   local includeDataMode = (ioddReadMessages[messageName].dataInfo.ProcessData and ioddReadMessages[messageName].dataInfo.Parameters)
   if ioddReadMessages[messageName].dataInfo.ProcessData then
-    if includeDataMode then
-      messageContent.ProcessData = {}
+    local readSuccess, receivedData = readProcessData(ioddReadMessages[messageName].dataInfo.ProcessData)
+    if not readSuccess then
+      success = false
     end
-    for dataPointID, dataPointInfo in pairs(ioddReadMessages[messageName].dataInfo.ProcessData) do
-      local receivedData = readProcessData(dataPointInfo)
-      if includeDataMode then
-        messageContent.ProcessData[dataPointID] = receivedData
-      else
-        messageContent[dataPointID] = receivedData
-      end
-      if not receivedData then
-        messageContent[dataPointID] = "nil"
-        success = false
-      end
+    if includeDataMode then
+      messageContent.ProcessData = receivedData
+    else
+      messageContent = receivedData
     end
   end
   if ioddReadMessages[messageName].dataInfo.Parameters then
@@ -380,15 +379,14 @@ local function readIODDMessage(messageName)
       messageContent.Parameters = {}
     end
     for dataPointID, dataPointInfo in pairs(ioddReadMessages[messageName].dataInfo.Parameters) do
-      local receivedData = readParameter(dataPointInfo)
+      local readSuccess, receivedData = readParameter(dataPointInfo)
+      if not readSuccess then
+        success = false
+      end
       if includeDataMode then
         messageContent.Parameters[dataPointID] = receivedData
       else
         messageContent[dataPointID] = receivedData
-      end
-      if not receivedData then
-        messageContent[dataPointID] = "nil"
-        success = false
       end
     end
   end
@@ -434,23 +432,28 @@ local function updateIODDReadMessages()
     end
     local localEventName = "readMessage" .. processingParams.port .. messageName
     local crownEventName = "CSK_MultiIOLinkSMI." .. localEventName
+
     local function readTheMessage()
       if not processingParams.active then
-        Script.notifyEvent(localEventName, false, ioddReadMessagesQueue:getSize(), 0,  nil)
+        Script.notifyEvent(localEventName, false, ioddReadMessagesQueue:getSize(), 0,  nil, 'IOLink port is not active')
         return
       end
       local timestamp1 = DateTime.getTimestamp()
       local success, jsonMessageContent = readIODDMessage(messageName)
-      local errorMessage
+      local errorMessage = ''
       local queueSize = ioddReadMessagesQueue:getSize()
+      if not success then
+        errorMessage = errorMessage .. ' Failed to read data from device;'
+      end
       if queueSize > 10 then
-        _G.logger:warning(nameOfModule..': reading queue is building up, clearing the queue, port ' .. tostring(processingParams.portNumber) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString .. '; current queue: ' .. tostring(queueSize))
-        errorMessage = 'Queue is building up: ' .. tostring(queueSize) ..' clearing the queue'
+        _G.logger:warning(nameOfModule..': reading queue is building up, clearing the queue, port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString .. '; current queue: ' .. tostring(queueSize))
+        errorMessage = errorMessage .. 'Queue is building up: ' .. tostring(queueSize) ..' clearing the queue'
         ioddReadMessagesQueue:clear()
       end
       local timestamp2 = DateTime.getTimestamp()
       Script.notifyEvent(localEventName, success, queueSize, timestamp2-timestamp1,  jsonMessageContent, errorMessage)
     end
+
     if not Script.isServedAsEvent(crownEventName) then
       Script.serveEvent(crownEventName, localEventName, 'bool:1:,int:1:,int:1:,string:?:,string:?:')
     end
@@ -467,7 +470,7 @@ local function updateIODDReadMessages()
       end
       ioddReadMessagesRegistrations[messageName][messageInfo.triggerValue] = readTheMessage
     end
-    table.insert(queueFunctions, readSources)
+    table.insert(queueFunctions, readTheMessage)
     ::nextMessage::
   end
   ioddReadMessagesQueue:setFunction(queueFunctions)
@@ -511,11 +514,8 @@ local function writeIODDMessage(messageName, jsonDataToWrite)
       elseif dataMode == 'Parameters' then
         success, errorCode = writeParameter(ioddWriteMessages[messageName].dataInfo.Parameters[dataPointID], dataPointDataToWrite)
       end
-      if errorCode then
-        if not errorMessage then
-          errorMessage = 'Error codes:'
-        end
-        errorMessage = errorMessage.. '; ' .. errorCode
+      if not success and not errorMessage and errorCode then
+        errorMessage = 'Error code:' .. errorCode .. ';'
       end
       messageWriteSuccess = messageWriteSuccess and success
     end
@@ -550,10 +550,18 @@ local function updateIODDWriteMessages()
         return false, ioddWriteMessagesQueue:getSize(), 0
       end
       local timestamp1 = DateTime.getTimestamp()
-      local messageWriteSuccess, errorMessage = writeIODDMessage(messageName, jsonDataToWrite)
+      local errorMessage = ''
+      local messageWriteSuccess, messageWriteErrorMessage = writeIODDMessage(messageName, jsonDataToWrite)
       local queueSize = ioddWriteMessagesQueue:getSize()
+      if not messageWriteSuccess then
+        errorMessage = errorMessage .. 'Failed to write data to device;'
+      end
+      if messageWriteErrorMessage then
+        errorMessage = errorMessage .. messageWriteErrorMessage
+      end
+
       if queueSize > 10 then
-        _G.logger:warning(nameOfModule..': writing queue is building up, clearing the queue, port ' .. tostring(processingParams.portNumber) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString .. '; current queue: ' .. tostring(queueSize))
+        _G.logger:warning(nameOfModule..': writing queue is building up, clearing the queue, port ' .. tostring(processingParams.port) .. ' instancenumber ' .. multiIOLinkSMIInstanceNumberString .. '; current queue: ' .. tostring(queueSize))
         errorMessage = 'Queue is building up: ' .. tostring(queueSize) ..' clearing the queue'
         ioddWriteMessagesQueue:clear()
       end

--- a/CSK_Module_MultiIOLinkSMI/scripts/Communication/MultiIOLinkSMI/MultiIOLinkSMI_Controller.lua
+++ b/CSK_Module_MultiIOLinkSMI/scripts/Communication/MultiIOLinkSMI/MultiIOLinkSMI_Controller.lua
@@ -1056,7 +1056,6 @@ Script.serveFunction('CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate', getIO
 --**************************************************************************
 
 
----@return string jsonCopiedDeviceConfig 
 local function getDeviceConfig()
   local copiedConfig = {
     deviceId = multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification.deviceId,

--- a/CSK_Module_MultiIOLinkSMI/scripts/Communication/MultiIOLinkSMI/MultiIOLinkSMI_Controller.lua
+++ b/CSK_Module_MultiIOLinkSMI/scripts/Communication/MultiIOLinkSMI/MultiIOLinkSMI_Controller.lua
@@ -108,6 +108,7 @@ Script.serveEvent('CSK_MultiIOLinkSMI.OnNewSerialNumber',                     'M
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewVendorId',                         'MultiIOLinkSMI_OnNewVendorId')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewVendorName',                       'MultiIOLinkSMI_OnNewVendorName')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewVendorText',                       'MultiIOLinkSMI_OnNewVendorText')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewDeviceId',                         'MultiIOLinkSMI_OnNewDeviceId')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProductId',                        'MultiIOLinkSMI_OnNewProductId')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProductName',                      'MultiIOLinkSMI_OnNewProductName')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProductText',                      'MultiIOLinkSMI_OnNewProductText')
@@ -120,6 +121,7 @@ Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceProductText',             'M
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceSerialNumber',            'MultiIOLinkSMI_OnNewNewDeviceSerialNumber')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceVendorId',                'MultiIOLinkSMI_OnNewNewDeviceVendorId')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceVendorText',              'MultiIOLinkSMI_OnNewNewDeviceVendorText')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId',                'MultiIOLinkSMI_OnNewNewDeviceDeviceId')
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewNewDeviceVendorName',              'MultiIOLinkSMI_OnNewNewDeviceVendorName')
 
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewStatusProcessDataVariable',        'MultiIOLinkSMI_OnNewStatusProcessDataVariable')
@@ -155,10 +157,11 @@ Script.serveEvent('CSK_MultiIOLinkSMI.OnNewReadProcessDataByteArray',         'M
 
 Script.serveEvent('CSK_MultiIOLinkSMI.OnNewTestCommandState',                 'MultiIOLinkSMI_OnNewTestCommandState')
 
-Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProcessDataInTableContentCSKIODDInterpreter', 'OnNewProcessDataInTableContentCSKIODDInterpreter')
-Script.serveEvent('CSK_MultiIOLinkSMI.OnNewReadParametersTableContentCSKIODDInterpreter', 'OnNewReadParametersTableContentCSKIODDInterpreter')
-Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProcessDataOutTableContentCSKIODDInterpreter', 'OnNewProcessDataOutTableContentCSKIODDInterpreter')
-Script.serveEvent('CSK_MultiIOLinkSMI.OnNewWriteParametersTableContentCSKIODDInterpreter', 'OnNewWriteParametersTableContentCSKIODDInterpreter')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProcessDataInTableContentCSKIODDInterpreter', 'MultiIOLinkSMI_OnNewProcessDataInTableContentCSKIODDInterpreter')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewReadParametersTableContentCSKIODDInterpreter', 'MultiIOLinkSMI_OnNewReadParametersTableContentCSKIODDInterpreter')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewProcessDataOutTableContentCSKIODDInterpreter', 'MultiIOLinkSMI_OnNewProcessDataOutTableContentCSKIODDInterpreter')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewWriteParametersTableContentCSKIODDInterpreter', 'MultiIOLinkSMI_OnNewWriteParametersTableContentCSKIODDInterpreter')
+Script.serveEvent('CSK_MultiIOLinkSMI.OnNewPortInformation', 'MultiIOLinkSMI_OnNewPortInformation')
 
 Script.serveEvent("CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot", "MultiIOLinkSMI_OnNewStatusLoadParameterOnReboot")
 Script.serveEvent("CSK_MultiIOLinkSMI.OnPersistentDataModuleAvailable", "MultiIOLinkSMI_OnPersistentDataModuleAvailable")
@@ -288,7 +291,6 @@ end
 -- Function to send all relevant values to UI on resume
 --@handleOnExpiredTmrMultiIOLinkSMI()
 local function handleOnExpiredTmrMultiIOLinkSMI()
-
   Script.notifyEvent("MultiIOLinkSMI_OnNewStatusModuleVersion", multiIOLinkSMI_Model.version)
   Script.notifyEvent("MultiIOLinkSMI_OnNewStatusCSKStyle", multiIOLinkSMI_Model.styleForUI)
   Script.notifyEvent('MultiIOLinkSMI_OnNewStatusModuleIsActive', _G.availableAPIs.default and _G.availableAPIs.specific)
@@ -378,10 +380,12 @@ local function handleOnExpiredTmrMultiIOLinkSMI()
         Script.notifyEvent('MultiIOLinkSMI_OnNewTriggerType', multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].triggerType)
         Script.notifyEvent('MultiIOLinkSMI_OnNewTriggerValue', tostring(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].triggerValue))
         Script.notifyEvent('MultiIOLinkSMI_OnNewReadMessageEventName', "CSK_MultiIOLinkSMI.readMessage" .. multiIOLinkSMI_Instances[selectedInstance].parameters.port .. selectedIODDReadMessage)
-        CSK_IODDInterpreter.pageCalledReadData()
         Script.notifyEvent('MultiIOLinkSMI_OnNewReadJSONTemplate', jsonTableViewer.jsonLine2Table(
           multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].jsonTemplate)
         )
+        local processDataTableContent, parameterTableContent = CSK_IODDInterpreter.getReadDataTableContents('readIOLink_')
+        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataInTableContentCSKIODDInterpreter', processDataTableContent)
+        Script.notifyEvent('MultiIOLinkSMI_OnNewReadParametersTableContentCSKIODDInterpreter', parameterTableContent)
       end
     elseif selectedTab == 2 then
       local nameList = {}
@@ -399,6 +403,9 @@ local function handleOnExpiredTmrMultiIOLinkSMI()
           multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].jsonTemplate)
         )
         Script.notifyEvent('MultiIOLinkSMI_OnNewTestWriteIODDMessage', testIODDMessageToWrite)
+        local processDataTableContent, parameterTableContent = CSK_IODDInterpreter.getWriteDataTableContents('writeIOLink_')
+        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataOutTableContentCSKIODDInterpreter', processDataTableContent)
+        Script.notifyEvent('MultiIOLinkSMI_OnNewWriteParametersTableContentCSKIODDInterpreter', parameterTableContent)
       end
     end
   end
@@ -431,8 +438,8 @@ local function setSelectedInstance(instance)
     testWriteParameterIndex = 0
     testWriteParameterSubindex = 0
     testIODDMessageToWrite = ''
-    if multiIOLinkSMI_Instances[selectedInstance].ioddInfo then
-      CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].ioddInfo.ioddInstanceId)
+    if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
+      CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId)
     end
     Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'activeInUi', true)
     handleOnExpiredTmrMultiIOLinkSMI()
@@ -443,6 +450,11 @@ end
 Script.serveFunction("CSK_MultiIOLinkSMI.setSelectedInstance", setSelectedInstance)
 
 local function setSelectedTab(tabNumber)
+  if not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
+    selectedTab = 0
+    handleOnExpiredTmrMultiIOLinkSMI()
+    return
+  end
   if tabNumber == 1 and selectedIODDReadMessage ~= '' then
     CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].ioddInstanceId)
   elseif tabNumber == 2 and selectedIODDWriteMessage ~= '' then
@@ -477,13 +489,24 @@ local function applyNewDeviceIdentificationUI()
   multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification = helperFuncs.copy(multiIOLinkSMI_Instances[selectedInstance].parameters.newDeviceIdentification)
   multiIOLinkSMI_Instances[selectedInstance].parameters.newDeviceIdentification = nil
   multiIOLinkSMI_Instances[selectedInstance]:applyNewDeviceIdentification()
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'readMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages))
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages))
   handleOnExpiredTmrMultiIOLinkSMI()
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.applyNewDeviceIdentificationUI', applyNewDeviceIdentificationUI)
 
-local function applyNewDeviceIdentification(jsonNewDeviceIdentification)
-  multiIOLinkSMI_Instances[selectedInstance].parameters.newDeviceIdentification = json.decode(jsonNewDeviceIdentification)
-  applyNewDeviceIdentificationUI()
+local function applyNewDeviceIdentification(instance, jsonNewDeviceIdentification)
+  if jsonNewDeviceIdentification then
+    multiIOLinkSMI_Instances[instance].parameters.newDeviceIdentification = json.decode(jsonNewDeviceIdentification)
+  end
+  multiIOLinkSMI_Instances[instance].parameters.deviceIdentification = helperFuncs.copy(multiIOLinkSMI_Instances[instance].parameters.newDeviceIdentification)
+  multiIOLinkSMI_Instances[instance].parameters.newDeviceIdentification = nil
+  multiIOLinkSMI_Instances[instance]:applyNewDeviceIdentification()
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'readMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages))
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages))
+  if instance == selectedInstance then
+    handleOnExpiredTmrMultiIOLinkSMI()
+  end
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.applyNewDeviceIdentification', applyNewDeviceIdentification)
 
@@ -494,17 +517,22 @@ Script.serveFunction('CSK_MultiIOLinkSMI.setProcessDataCondition', setProcessDat
 
 --- Function called when there is a new IODD file loaded or deleted in CSK_Module_IODDInterpreter to check if there are any updates for existing instances.
 local function handleOnIODDListChanged()
+  if not multiIOLinkSMI_Instances then
+    return
+  end
   for instance, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
-    local foundMatchingIODD, _ = CSK_IODDInterpreter.findIODDMatchingVendorIdDeviceIdVersion(
-      instanceInfo.parameters.deviceIdentification.vendorId,
-      instanceInfo.parameters.deviceIdentification.deviceId
-    )
-    if foundMatchingIODD and not instanceInfo.parameters.ioddInfo or not foundMatchingIODD and instanceInfo.parameters.ioddInfo then
-      selectedIODDReadMessage = ''
-      selectedIODDWriteMessage = ''
-      multiIOLinkSMI_Instances[instance]:applyNewDeviceIdentification()
-      Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'readMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages))
-      Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages))
+    if instanceInfo.parameters.deviceIdentification then
+      local foundMatchingIODD, _ = CSK_IODDInterpreter.findIODDMatchingVendorIdDeviceIdVersion(
+        instanceInfo.parameters.deviceIdentification.vendorId,
+        instanceInfo.parameters.deviceIdentification.deviceId
+      )
+      if foundMatchingIODD and not instanceInfo.parameters.ioddInfo or not foundMatchingIODD and instanceInfo.parameters.ioddInfo then
+        selectedIODDReadMessage = ''
+        selectedIODDWriteMessage = ''
+        multiIOLinkSMI_Instances[instance]:applyNewDeviceIdentification()
+        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'readMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages))
+        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages))
+      end
     end
   end
   tmrMultiIOLinkSMI:start()
@@ -533,36 +561,69 @@ local function handleOnNewPortEvent(port, eventType, eventCode)
       local portStatus = multiIOLinkSMI_Model.IOLinkSMIhandle:getPortStatus(port)
       multiIOLinkSMI_Instances[instanceNumber].status = portStatus:getPortStatusInfo()
       Script.notifyEvent('MultiIOLinkSMI_OnNewIOLinkPortStatus', instanceNumber, multiIOLinkSMI_Instances[instanceNumber].status)
+      break
     end
   end
   if eventCode == 0xFF26 and updatedInstanceNumber ~= nil then
-    setSelectedInstance(updatedInstanceNumber)
+
     local deviceInfo = multiIOLinkSMI_Model.getDeviceIdentification(port)
     if deviceInfo.deviceId == '' then
-      handleOnExpiredTmrMultiIOLinkSMI()
-      return
-    end
-    if not CSK_IODDInterpreter then
+      --do nothing
+    elseif not CSK_IODDInterpreter then
       multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification = deviceInfo
-      handleOnExpiredTmrMultiIOLinkSMI()
-      return
     elseif not multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification then
       multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.newDeviceIdentification = deviceInfo
-      applyNewDeviceIdentificationUI()
+      applyNewDeviceIdentification(updatedInstanceNumber)
       return
     elseif multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification.vendorId == deviceInfo.vendorId and
     multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification.deviceId == deviceInfo.deviceId then
       multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification = deviceInfo
-      handleOnExpiredTmrMultiIOLinkSMI()
-      return
+      multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.newDeviceIdentification = nil
+      if multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.ioddInfo and
+      multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.isProcessDataVariable and
+      multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.ioddInfo.currentCondition then
+        multiIOLinkSMI_Instances[updatedInstanceNumber]:setProcessDataConditionName(multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.ioddInfo.currentCondition)
+      end
     else
       multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.newDeviceIdentification = deviceInfo
-      handleOnExpiredTmrMultiIOLinkSMI()
-      return
     end
+
+    local jsonIdentification, jsonNewIdentification, ioddName
+    if multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification then
+      jsonIdentification = json.encode(multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.deviceIdentification)
+    end
+    if multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.newDeviceIdentification then
+      jsonNewIdentification = json.encode(multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.newDeviceIdentification)
+    end
+    if multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.ioddInfo then
+      ioddName = multiIOLinkSMI_Instances[updatedInstanceNumber].parameters.ioddInfo.ioddName
+    end
+
+    Script.notifyEvent(
+      'MultiIOLinkSMI_OnNewPortInformation',
+      updatedInstanceNumber,
+      port,
+      multiIOLinkSMI_Instances[updatedInstanceNumber].status,
+      jsonIdentification,
+      ioddName,
+      jsonNewIdentification
+    )
+    handleOnExpiredTmrMultiIOLinkSMI()
   end
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.handleOnNewPortEvent', handleOnNewPortEvent)
+
+---@return string jsonInstancePortMap 
+local function getInstancePortMap()
+  local map = {}
+  for instanceId, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
+    if instanceInfo.parameters.active then
+      map[tostring(instanceId)] = instanceInfo.parameters.port
+    end
+  end
+  return json.encode(map)
+end
+Script.serveFunction('CSK_MultiIOLinkSMI.getInstancePortMap', getInstancePortMap)
 
 --**************************************************************************
 --*************Read / Write Functions to be used externally ****************
@@ -576,7 +637,7 @@ local function readProcessData()
   local processDataInfo = json.decode(jsonDataPointInfo)
   local readSuccess, readData = Script.callFunction(
     'CSK_MultiIOLinkSMI.readProcessDataIODD_' .. tostring(selectedInstance),
-    json.encode(processDataInfo.ProcessDataIn.Datatype)
+    json.encode(processDataInfo.ProcessDataIn)
   )
   return readSuccess, readData
 end
@@ -598,40 +659,13 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.writeProcessData', writeProcessData)
 
 local function readParameter(index, subindex)
-  local jsonDataPointInfo = CSK_IODDInterpreter.getParameterDataPointInfo(
-    multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId,
-    index,
-    subindex
-  )
-  if not jsonDataPointInfo then
-    return false, nil
-  end
-  local readSuccess, readData = Script.callFunction(
-    'CSK_MultiIOLinkSMI.readParameterIODD_' .. tostring(selectedInstance),
-    index,
-    subindex,
-    jsonDataPointInfo
-  )
+  local readSuccess, readData = multiIOLinkSMI_Instances[selectedInstance]:readParameter(index, subindex)
   return readSuccess, readData
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.readParameter', readParameter)
 
 local function writeParameter(index, subindex, jsonDataToWrite)
-  local jsonDataPointInfo = CSK_IODDInterpreter.getParameterDataPointInfo(
-    multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId,
-    index,
-    subindex
-  )
-  if not jsonDataPointInfo then
-    return false
-  end
-  local callSuccess, writeSuccess = Script.callFunction(
-    'CSK_MultiIOLinkSMI.writeParameterIODD_' .. tostring(selectedInstance),
-    index,
-    subindex,
-    jsonDataPointInfo,
-    jsonDataToWrite
-  )
+  local writeSuccess = multiIOLinkSMI_Instances[selectedInstance]:writeParameter(index, subindex, jsonDataToWrite)
   return writeSuccess
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.writeParameter', writeParameter)
@@ -769,8 +803,14 @@ Script.serveFunction('CSK_MultiIOLinkSMI.writeParameterByteArrayUI', writeParame
 --**************************************************************************
 
 local function setSelectedIODDReadMessage(newSelectedMessage)
+  if newSelectedMessage == '' then
+    selectedIODDReadMessage = newSelectedMessage
+  end
+  if selectedInstance == '' or not multiIOLinkSMI_Instances[selectedInstance] or not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[newSelectedMessage] then
+    return
+  end
   selectedIODDReadMessage = newSelectedMessage
-  if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[newSelectedMessage] ~= nil then
+  if selectedIODDReadMessage ~= '' then
     CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].ioddInstanceId)
   end
   handleOnExpiredTmrMultiIOLinkSMI()
@@ -778,15 +818,15 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.setSelectedIODDReadMessage', setSelectedIODDReadMessage)
 
 local function createIODDReadMessage()
-  if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
-    if newReadMessageName ~= '' and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[newReadMessageName] == nil then
-      multiIOLinkSMI_Instances[selectedInstance]:createIODDReadMessage(newReadMessageName)
-      setSelectedIODDReadMessage(newReadMessageName)
-    else
-      _G.logger:info(nameOfModule .. ": No name for readMessage")
-    end
-  else
+  if not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
     _G.logger:info(nameOfModule .. ": No IODD info to create readMessage")
+    return
+  end
+  if newReadMessageName ~= '' and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[newReadMessageName] == nil then
+    multiIOLinkSMI_Instances[selectedInstance]:createIODDReadMessage(newReadMessageName)
+    setSelectedIODDReadMessage(newReadMessageName)
+  else
+    _G.logger:info(nameOfModule .. ": No name for readMessage")
   end
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.createIODDReadMessage', createIODDReadMessage)
@@ -807,6 +847,7 @@ local function deleteIODDReadMessage()
   multiIOLinkSMI_Instances[selectedInstance]:deleteIODDReadMessage(selectedIODDReadMessage)
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'readMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages))
   setSelectedIODDReadMessage('')
+  handleOnExpiredTmrMultiIOLinkSMI()
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.deleteIODDReadMessage', deleteIODDReadMessage)
 
@@ -837,27 +878,27 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.setTriggerValue', setTriggerValue)
 
 
---- Function called when new data set selected in read data tables of CSK_Module_IODDInterpreter to update the existing IODD read messages accordingly.
-local function handleOnNewReadDataJsonTemplateAndInfo(ioddInstanceId, jsonTemplate, jsonDataInfo)
-  for instance, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
-    for messageName, messageInfo in pairs(instanceInfo.parameters.ioddReadMessages) do
-      if ioddInstanceId == messageInfo.ioddInstanceId then
-        multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages[messageName].jsonTemplate = jsonTemplate
-        multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages[messageName].dataInfo = json.decode(jsonDataInfo)
-        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'readMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages))
-        break
-      end
-    end
-  end
-  if selectedInstance and selectedIODDReadMessage ~= '' then
-    Script.notifyEvent('MultiIOLinkSMI_OnNewReadJSONTemplate', jsonTableViewer.jsonLine2Table(
-      multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].jsonTemplate)
-    )
-  end
-end
-if CSK_IODDInterpreter then
-  Script.register('CSK_IODDInterpreter.OnNewReadDataJsonTemplateAndInfo', handleOnNewReadDataJsonTemplateAndInfo)
-end
+----- Function called when new data set selected in read data tables of CSK_Module_IODDInterpreter to update the existing IODD read messages accordingly.
+--local function handleOnNewReadDataJsonTemplateAndInfo(ioddInstanceId, jsonTemplate, jsonDataInfo)
+--  for instance, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
+--    for messageName, messageInfo in pairs(instanceInfo.parameters.ioddReadMessages) do
+--      if ioddInstanceId == messageInfo.ioddInstanceId then
+--        multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages[messageName].jsonTemplate = jsonTemplate
+--        multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages[messageName].dataInfo = json.decode(jsonDataInfo)
+--        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'readMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddReadMessages))
+--        break
+--      end
+--    end
+--  end
+--  if selectedInstance and selectedIODDReadMessage ~= '' then
+--    Script.notifyEvent('MultiIOLinkSMI_OnNewReadJSONTemplate', jsonTableViewer.jsonLine2Table(
+--      multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].jsonTemplate)
+--    )
+--  end
+--end
+--if CSK_IODDInterpreter then
+--  Script.register('CSK_IODDInterpreter.OnNewReadDataJsonTemplateAndInfo', handleOnNewReadDataJsonTemplateAndInfo)
+--end
 
 local function refreshReadDataResult()
   if selectedIODDReadMessage == '' then
@@ -900,6 +941,12 @@ Script.serveFunction('CSK_MultiIOLinkSMI.getIODDReadMessageJSONTemplate', getIOD
 --**************************************************************************
 
 local function setSelectedIODDWriteMessage(newSelectedMessage)
+  if newSelectedMessage == '' then
+    selectedIODDWriteMessage = newSelectedMessage
+  end
+  if selectedInstance == '' or not multiIOLinkSMI_Instances[selectedInstance] or not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[newSelectedMessage] then
+    return
+  end
   selectedIODDWriteMessage = newSelectedMessage
   if selectedIODDWriteMessage ~= '' then
     CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].ioddInstanceId)
@@ -909,15 +956,15 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.setSelectedIODDWriteMessage', setSelectedIODDWriteMessage)
 
 local function createIODDWriteMessage()
-  if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
-    if newWriteMessageName ~= '' and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[newWriteMessageName] == nil then
-      multiIOLinkSMI_Instances[selectedInstance]:createIODDWriteMessage(newWriteMessageName)
-      setSelectedIODDWriteMessage(newWriteMessageName)
-    else
-      _G.logger:info(nameOfModule .. ": No name for writeMessage")
-    end
-  else
+  if not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
     _G.logger:info(nameOfModule .. ": No IODD info to create writeMessage")
+    return
+  end
+  if newWriteMessageName ~= '' and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[newWriteMessageName] == nil then
+    multiIOLinkSMI_Instances[selectedInstance]:createIODDWriteMessage(newWriteMessageName)
+    setSelectedIODDWriteMessage(newWriteMessageName)
+  else
+    _G.logger:info(nameOfModule .. ": No name for writeMessage")
   end
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.createIODDWriteMessage', createIODDWriteMessage)
@@ -941,27 +988,27 @@ local function deleteIODDWriteMessage()
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.deleteIODDWriteMessage', deleteIODDWriteMessage)
 
---- Function called when new data set selected in write data tables of CSK_Module_IODDInterpreter to update the existing IODD write messages accordingly.
-local function handleOnNewWriteDataJsonTemplateAndInfo(ioddInstanceId, jsonTemplate, jsonDataInfo)
-  for instance, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
-    for messageName, messageInfo in pairs(instanceInfo.parameters.ioddWriteMessages) do
-      if ioddInstanceId == messageInfo.ioddInstanceId then
-        multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages[messageName].jsonTemplate = jsonTemplate
-        multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages[messageName].dataInfo = json.decode(jsonDataInfo)
-        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages))
-        break
-      end
-    end
-  end
-  if selectedInstance and selectedIODDWriteMessage ~= '' then
-    Script.notifyEvent('MultiIOLinkSMI_OnNewWriteJSONTemplate', jsonTableViewer.jsonLine2Table(
-      multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].jsonTemplate)
-    )
-  end
-end
-if CSK_IODDInterpreter then
-  Script.register('CSK_IODDInterpreter.OnNewWriteDataJsonTemplateAndInfo', handleOnNewWriteDataJsonTemplateAndInfo)
-end
+----- Function called when new data set selected in write data tables of CSK_Module_IODDInterpreter to update the existing IODD write messages accordingly.
+--local function handleOnNewWriteDataJsonTemplateAndInfo(ioddInstanceId, jsonTemplate, jsonDataInfo)
+--  for instance, instanceInfo in ipairs(multiIOLinkSMI_Instances) do
+--    for messageName, messageInfo in pairs(instanceInfo.parameters.ioddWriteMessages) do
+--      if ioddInstanceId == messageInfo.ioddInstanceId then
+--        multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages[messageName].jsonTemplate = jsonTemplate
+--        multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages[messageName].dataInfo = json.decode(jsonDataInfo)
+--        Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', instance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[instance].parameters.ioddWriteMessages))
+--        break
+--      end
+--    end
+--  end
+--  if selectedInstance and selectedIODDWriteMessage ~= '' then
+--    Script.notifyEvent('MultiIOLinkSMI_OnNewWriteJSONTemplate', jsonTableViewer.jsonLine2Table(
+--      multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].jsonTemplate)
+--    )
+--  end
+--end
+--if CSK_IODDInterpreter then
+--  Script.register('CSK_IODDInterpreter.OnNewWriteDataJsonTemplateAndInfo', handleOnNewWriteDataJsonTemplateAndInfo)
+--end
 
 local function refreshWriteDataResult()
   if selectedIODDWriteMessage == '' then
@@ -1005,29 +1052,47 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate', getIODDWriteMessageJSONTemplate)
 
 --**************************************************************************
+--*************Copy/Paste device configuration from outside*****************
+--**************************************************************************
+
+
+---@return string jsonCopiedDeviceConfig 
+local function getDeviceConfig()
+  local copiedConfig = {
+    deviceId = multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification.deviceId,
+    vendorId = multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification.vendorId,
+    processDataCondition = multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.currentCondition,
+    ioddReadMessages = multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages,
+    ioddWriteMessages = multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages
+  }
+  return json.encode(copiedConfig)
+end
+Script.serveFunction('CSK_MultiIOLinkSMI.getDeviceConfig', getDeviceConfig)
+
+
+--**************************************************************************
 --*************Forwarding data to/from CSK_IODDInterpreter scope************
 --**************************************************************************
 
+--- Function called when new data set selected in read data tables of CSK_Module_IODDInterpreter to update the existing IODD read messages accordingly.
+local function handleOnNewReadDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+  multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].jsonTemplate = jsonTemplate
+  multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].dataInfo = json.decode(jsonDataInfo)
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'readMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages))
+  Script.notifyEvent('MultiIOLinkSMI_OnNewReadJSONTemplate', jsonTableViewer.jsonLine2Table(jsonTemplate))
+end
+
+
+--- Function called when new data set selected in write data tables of CSK_Module_IODDInterpreter to update the existing IODD write messages accordingly.
+local function handleOnNewWriteDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+  multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].jsonTemplate = jsonTemplate
+  multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].dataInfo = json.decode(jsonDataInfo)
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages))
+  Script.notifyEvent('MultiIOLinkSMI_OnNewWriteJSONTemplate', jsonTableViewer.jsonLine2Table(jsonTemplate))
+end
+
+
 if CSK_IODDInterpreter then
-  local function handleOnNewProcessDataInTableContentCSKIODDInterpreter(tableContent)
-    Script.notifyEvent('OnNewProcessDataInTableContentCSKIODDInterpreter', tableContent)
-  end
-  Script.register('CSK_IODDInterpreter.OnNewProcessDataInTableContent', handleOnNewProcessDataInTableContentCSKIODDInterpreter)
-
-  local function handleOnNewReadParametersTableContentCSKIODDInterpreter(tableContent)
-    Script.notifyEvent('OnNewReadParametersTableContentCSKIODDInterpreter', tableContent)
-  end
-  Script.register('CSK_IODDInterpreter.OnNewReadParametersTableContent', handleOnNewReadParametersTableContentCSKIODDInterpreter)
-
-  local function handleOnNewProcessDataOutTableContentCSKIODDInterpreter(tableContent)
-    Script.notifyEvent('OnNewProcessDataOutTableContentCSKIODDInterpreter', tableContent)
-  end
-  Script.register('CSK_IODDInterpreter.OnNewProcessDataOutTableContent', handleOnNewProcessDataOutTableContentCSKIODDInterpreter)
-
-  local function handleOnNewWriteParametersTableContentCSKIODDInterpreter(tableContent)
-    Script.notifyEvent('OnNewWriteParametersTableContentCSKIODDInterpreter', tableContent)
-  end
-  Script.register('CSK_IODDInterpreter.OnNewWriteParametersTableContent', handleOnNewWriteParametersTableContentCSKIODDInterpreter)
 
   local function uploadFinishedCSKIODDInterpreter(uploadSuccess)
     CSK_IODDInterpreter.uploadFinished(uploadSuccess)
@@ -1035,24 +1100,87 @@ if CSK_IODDInterpreter then
   Script.serveFunction('CSK_MultiIOLinkSMI.uploadFinishedCSKIODDInterpreter', uploadFinishedCSKIODDInterpreter)
 
   local function processDataInRowSelectedCSKIODDInterpreter(rowData)
-    CSK_IODDInterpreter.processDataInRowSelected(rowData)
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.processDataInRowSelected(rowData, 'readIOLink_')
+    handleOnNewReadDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local processDataTableContent = CSK_IODDInterpreter.getReadDataTableContents('readIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataInTableContentCSKIODDInterpreter', processDataTableContent)
   end
   Script.serveFunction('CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter', processDataInRowSelectedCSKIODDInterpreter)
 
   local function readParameterRowSelectedCSKIODDInterpreter(rowData)
-    CSK_IODDInterpreter.readParameterRowSelected(rowData)
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.readParameterRowSelected(rowData, 'readIOLink_')
+    handleOnNewReadDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local _, parameterTableContent = CSK_IODDInterpreter.getReadDataTableContents('readIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewReadParametersTableContentCSKIODDInterpreter', parameterTableContent)
   end
   Script.serveFunction('CSK_MultiIOLinkSMI.readParameterRowSelectedCSKIODDInterpreter', readParameterRowSelectedCSKIODDInterpreter)
 
   local function processDataOutRowSelectedCSKIODDInterpreter(rowData)
-    CSK_IODDInterpreter.processDataOutRowSelected(rowData)
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.processDataOutRowSelected(rowData, 'writeIOLink_')
+    handleOnNewWriteDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local processDataTableContent = CSK_IODDInterpreter.getWriteDataTableContents('writeIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataOutTableContentCSKIODDInterpreter', processDataTableContent)
   end
   Script.serveFunction('CSK_MultiIOLinkSMI.processDataOutRowSelectedCSKIODDInterpreter', processDataOutRowSelectedCSKIODDInterpreter)
 
   local function writeParameterRowSelectedCSKIODDInterpreter(rowData)
-    CSK_IODDInterpreter.writeParameterRowSelected(rowData)
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.writeParameterRowSelected(rowData, 'writeIOLink_')
+    handleOnNewWriteDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local _, parameterTableContent = CSK_IODDInterpreter.getWriteDataTableContents('writeIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewWriteParametersTableContentCSKIODDInterpreter', parameterTableContent)
   end
   Script.serveFunction('CSK_MultiIOLinkSMI.writeParameterRowSelectedCSKIODDInterpreter', writeParameterRowSelectedCSKIODDInterpreter)
+
+
+  local function copyReadDataMessage()
+    CSK_IODDInterpreter.copyReadDataMessage()
+  end
+  Script.serveFunction('CSK_MultiIOLinkSMI.copyReadDataMessage', copyReadDataMessage)
+
+  ---@return string? processDataTableContent 
+  ---@return string? parameterTableContent 
+  ---@return string? jsonTemplate 
+  local function pasteReadDataMessage()
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.pasteReadDataMessage()
+    if not jsonTemplate then
+      return nil, nil, nil
+    end
+    handleOnNewReadDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local processDataTableContent, parameterTableContent = CSK_IODDInterpreter.getReadDataTableContents('readIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataInTableContentCSKIODDInterpreter', processDataTableContent)
+    Script.notifyEvent('MultiIOLinkSMI_OnNewReadParametersTableContentCSKIODDInterpreter', parameterTableContent)
+    if not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage] then
+      return processDataTableContent, parameterTableContent, nil
+    end
+    return processDataTableContent, parameterTableContent, multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages[selectedIODDReadMessage].jsonTemplate
+  end
+  Script.serveFunction('CSK_MultiIOLinkSMI.pasteReadDataMessage', pasteReadDataMessage)
+
+
+  local function copyWriteDataMessage()
+    CSK_IODDInterpreter.copyWriteDataMessage()
+  end
+  Script.serveFunction('CSK_MultiIOLinkSMI.copyWriteDataMessage', copyWriteDataMessage)
+
+  ---@return string? processDataTableContent 
+  ---@return string? parameterTableContent 
+  ---@return string? jsonTemplate 
+  local function pasteWriteDataMessage()
+    local jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.pasteWriteDataMessage()
+    if not jsonTemplate then
+      return nil, nil, nil
+    end
+    handleOnNewWriteDataJsonTemplateAndInfo(jsonTemplate, jsonDataInfo)
+    local processDataTableContent, parameterTableContent = CSK_IODDInterpreter.getWriteDataTableContents('writeIOLink_')
+    Script.notifyEvent('MultiIOLinkSMI_OnNewProcessDataOutTableContentCSKIODDInterpreter', processDataTableContent)
+    Script.notifyEvent('MultiIOLinkSMI_OnNewWriteParametersTableContentCSKIODDInterpreter', parameterTableContent)
+    if not multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage] then
+      return processDataTableContent, parameterTableContent, nil
+    end
+    return processDataTableContent, parameterTableContent, multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages[selectedIODDWriteMessage].jsonTemplate
+  end
+  Script.serveFunction('CSK_MultiIOLinkSMI.pasteWriteDataMessage', pasteWriteDataMessage)
+
 end
 
 --**************************************************************************
@@ -1080,17 +1208,29 @@ end
 Script.serveFunction('CSK_MultiIOLinkSMI.getInstanceParameters', getInstanceParameters)
 
 local function makeDefaultInstance()
+  for messageName in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages) do
+    setSelectedIODDReadMessage(messageName)
+    deleteIODDReadMessage()
+  end
+  for messageName in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages) do
+    setSelectedIODDWriteMessage(messageName)
+    deleteIODDWriteMessage()
+  end
   selectedIODDReadMessage = ''
   selectedIODDWriteMessage = ''
   multiIOLinkSMI_Instances[selectedInstance].status = 'PORT_NOT_ACTIVE'
   multiIOLinkSMI_Instances[selectedInstance].parameters.port = ''
   multiIOLinkSMI_Instances[selectedInstance].parameters.active = false
   multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo = nil
+  multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification = nil
+  multiIOLinkSMI_Instances[selectedInstance].parameters.newDeviceIdentification = nil
   multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages = {}
   multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages = {}
   multiIOLinkSMI_Instances[selectedInstance].parameters.ReadJSONTemplate = '[]'
   multiIOLinkSMI_Instances[selectedInstance].parameters.WriteJSONTemplate = '[]'
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'active', multiIOLinkSMI_Instances[selectedInstance].parameters.active)
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages))
+  Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'readMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages))
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'port', multiIOLinkSMI_Instances[selectedInstance].parameters.port)
 end
 Script.serveFunction('CSK_MultiIOLinkSMI.makeDefaultInstance', makeDefaultInstance)
@@ -1112,6 +1252,36 @@ Script.serveFunction('CSK_MultiIOLinkSMI.resetInstances', resetInstances)
 local function updateProcessingParameters()
   selectedIODDReadMessage = ''
   selectedIODDWriteMessage = ''
+  if multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification and CSK_IODDInterpreter then
+    local instanceInfo = multiIOLinkSMI_Instances[selectedInstance]
+    local foundMatchingIODD, _ = CSK_IODDInterpreter.findIODDMatchingVendorIdDeviceIdVersion(
+      instanceInfo.parameters.deviceIdentification.vendorId,
+      instanceInfo.parameters.deviceIdentification.deviceId
+    )
+    if not foundMatchingIODD and instanceInfo.parameters.ioddInfo then
+      for messageName, _ in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages) do
+        multiIOLinkSMI_Instances[selectedInstance]:deleteIODDReadMessage(messageName)
+      end
+      for messageName, _ in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages) do
+        multiIOLinkSMI_Instances[selectedInstance]:deleteIODDWriteMessage(messageName)
+      end
+      if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId then
+        CSK_IODDInterpreter.setSelectedInstance(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId)
+        CSK_IODDInterpreter.deleteInstance()
+      end
+      multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo = nil
+      Script.notifyEvent(
+        'MultiIOLinkSMI_OnNewPortInformation',
+        multiIOLinkSMI_Instances[selectedInstance].multiIOLinkSMIInstanceNo,
+        multiIOLinkSMI_Instances[selectedInstance].parameters.port,
+        multiIOLinkSMI_Instances[selectedInstance].status,
+        json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.deviceIdentification),
+        nil,
+        nil
+      )
+      Script.notifyEvent('MultiIOLinkSMI_OnNewDeviceIdentificationApplied', multiIOLinkSMI_Instances[selectedInstance].multiIOLinkSMIInstanceNo, json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters))
+    end
+  end
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'port', multiIOLinkSMI_Instances[selectedInstance].parameters.port)
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'readMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages))
   Script.notifyEvent('MultiIOLinkSMI_OnNewProcessingParameter', selectedInstance, 'writeMessages', json.encode(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages))
@@ -1155,10 +1325,21 @@ Script.serveFunction("CSK_MultiIOLinkSMI.setParameterName", setParameterName)
 
 local function sendParameters(noDataSave)
   if multiIOLinkSMI_Instances[selectedInstance].persistentModuleAvailable then
-    if CSK_IODDInterpreter and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
-      CSK_IODDInterpreter.setParameterName(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId)
-      CSK_IODDInterpreter.sendParameters()
+    ---------------------------------
+    if CSK_IODDInterpreter then
+      local ioddInstancesToSave = {}
+      if multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
+        table.insert(ioddInstancesToSave, multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId)
+      end
+      for _, messageInfo in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddReadMessages) do
+        table.insert(ioddInstancesToSave, messageInfo.ioddInstanceId)
+      end
+      for _, messageInfo in pairs(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddWriteMessages) do
+        table.insert(ioddInstancesToSave, messageInfo.ioddInstanceId)
+      end
+      CSK_IODDInterpreter.sendInstancesListParameters('iolinkSMI' .. tostring(selectedInstance), ioddInstancesToSave)
     end
+    ---------------------------------
 
     CSK_PersistentData.addParameter(helperFuncs.convertTable2Container(multiIOLinkSMI_Instances[selectedInstance].parameters), multiIOLinkSMI_Instances[selectedInstance].parametersName)
 
@@ -1183,12 +1364,14 @@ local function loadParameters()
     local data = CSK_PersistentData.getParameter(multiIOLinkSMI_Instances[selectedInstance].parametersName)
     if data then
       _G.logger:info(nameOfModule .. ": Loaded parameters for multiIOLinkSMIObject " .. tostring(selectedInstance) .. " from PersistentData module.")
+            ---------------------------------------
+            if CSK_IODDInterpreter then
+              CSK_IODDInterpreter.loadInstancesListParameters('iolinkSMI' .. tostring(selectedInstance))
+            end
+            ---------------------------------------
       multiIOLinkSMI_Instances[selectedInstance].parameters = helperFuncs.convertContainer2Table(data)
       updateProcessingParameters()
-      if CSK_IODDInterpreter and multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo then
-        CSK_IODDInterpreter.setParameterName(multiIOLinkSMI_Instances[selectedInstance].parameters.ioddInfo.ioddInstanceId)
-        CSK_IODDInterpreter.loadParameters()
-      end
+
       tmrMultiIOLinkSMI:start()
       return true
     else

--- a/docu/CSK_Module_MultiIOLinkSMI.html
+++ b/docu/CSK_Module_MultiIOLinkSMI.html
@@ -619,7 +619,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
 <span id="revnumber">version 2.0.0,</span>
-<span id="revdate">2024-08-14</span>
+<span id="revdate">2024-10-21</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -644,12 +644,16 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.applyNewDeviceIdentification"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">applyNewDeviceIdentification()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.applyNewDeviceIdentificationUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">applyNewDeviceIdentificationUI()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.clearFlowConfigRelevantConfiguration"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">clearFlowConfigRelevantConfiguration()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.copyReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyReadDataMessage()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.copyWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyWriteDataMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.createIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">createIODDReadMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.createIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">createIODDWriteMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.deleteIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">deleteIODDReadMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.deleteIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">deleteIODDWriteMessage()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.getDeviceConfig"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceConfig()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.getDeviceIdentification"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceIdentification()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.getInstanceParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstanceParameters()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.getInstancePortMap"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancePortMap()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.getInstancesAmount"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancesAmount()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.getIODDReadMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDReadMessageJSONTemplate()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDWriteMessageJSONTemplate()</span></a></li>
@@ -662,6 +666,8 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.loadParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">loadParameters()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.makeDefaultInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">makeDefaultInstance()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.pageCalled"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pageCalled()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.pasteReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteReadDataMessage()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.pasteWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteWriteDataMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataInRowSelectedCSKIODDInterpreter()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.processDataOutRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataOutRowSelectedCSKIODDInterpreter()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.readIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessage()</span></a></li>
@@ -708,6 +714,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessage()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeIODDMessageFromUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageFromUI()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeIODDMessageNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageNUM()</span></a></li>
+<li><a href="#API:Function:CSK_MultiIOLinkSMI.writeMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeMessagePortMessageName()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameter()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray()</span></a></li>
 <li><a href="#API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray_NUM()</span></a></li>
@@ -724,6 +731,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#_events">Events</a>
 <ul class="sectlevel4">
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnDataLoadedOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnDataLoadedOnReboot</span></a></li>
+<li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceId</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewDeviceIdentificationApplied"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceIdentificationApplied</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewFirmwareVersion</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewHardwareVersion</span></a></li>
@@ -732,6 +740,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewListIODDReadMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDReadMessages</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewListIODDWriteMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDWriteMessages</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewListProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListProcessDataCondition</span></a></li>
+<li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceDeviceId</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceFirmwareVersion</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceHardwareVersion</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductId</span></a></li>
@@ -745,6 +754,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPort</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortDropdown"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortDropdown</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortEvent"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortEvent</span></a></li>
+<li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortInformation"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortInformation</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortStatus"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortStatus</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataCondition</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataInTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataInTableContentCSKIODDInterpreter</span></a></li>
@@ -797,19 +807,20 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelMaintenanceActive</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelOperatorActive</span></a></li>
 <li><a href="#API:Event:CSK_MultiIOLinkSMI.OnUserLevelServiceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelServiceActive</span></a></li>
+<li><a href="#API:Event:CSK_MultiIOLinkSMI.readMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">readMessagePortMessageName</span></a></li>
 </ul>
 </li>
 </ul>
 </li>
 <li><a href="#API:Crown:MultiIOLinkSMI_FC"><span class="api-crown">MultiIOLinkSMI_FC</span></a>
 <ul class="sectlevel3">
-<li><a href="#_short_description_156">Short description</a></li>
+<li><a href="#_short_description_160">Short description</a></li>
 <li><a href="#_overview_3">Overview</a></li>
 </ul>
 </li>
 <li><a href="#API:Crown:MultiIOLinkSMI_FC.OnNewData"><span class="api-crown">MultiIOLinkSMI_FC.OnNewData</span></a>
 <ul class="sectlevel3">
-<li><a href="#_short_description_157">Short description</a></li>
+<li><a href="#_short_description_161">Short description</a></li>
 <li><a href="#_overview_4">Overview</a></li>
 <li><a href="#_functions_2">Functions</a>
 <ul class="sectlevel4">
@@ -849,7 +860,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-21</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -983,6 +994,12 @@ The following functions can be used for reading or writing data by selected inst
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.clearFlowConfigRelevantConfiguration">clearFlowConfigRelevantConfiguration()</a></p>
 </li>
 <li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.copyReadDataMessage">copyReadDataMessage()</a></p>
+</li>
+<li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.copyWriteDataMessage">copyWriteDataMessage()</a></p>
+</li>
+<li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.createIODDReadMessage">createIODDReadMessage()</a></p>
 </li>
 <li>
@@ -995,10 +1012,16 @@ The following functions can be used for reading or writing data by selected inst
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.deleteIODDWriteMessage">deleteIODDWriteMessage()</a></p>
 </li>
 <li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.getDeviceConfig">getDeviceConfig()</a></p>
+</li>
+<li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.getDeviceIdentification">getDeviceIdentification()</a></p>
 </li>
 <li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.getInstanceParameters">getInstanceParameters()</a></p>
+</li>
+<li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.getInstancePortMap">getInstancePortMap()</a></p>
 </li>
 <li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.getInstancesAmount">getInstancesAmount()</a></p>
@@ -1035,6 +1058,12 @@ The following functions can be used for reading or writing data by selected inst
 </li>
 <li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.pageCalled">pageCalled()</a></p>
+</li>
+<li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.pasteReadDataMessage">pasteReadDataMessage()</a></p>
+</li>
+<li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.pasteWriteDataMessage">pasteWriteDataMessage()</a></p>
 </li>
 <li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter">processDataInRowSelectedCSKIODDInterpreter()</a></p>
@@ -1175,6 +1204,9 @@ The following functions can be used for reading or writing data by selected inst
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.writeIODDMessageNUM">writeIODDMessageNUM()</a></p>
 </li>
 <li>
+<p><a href="#API:Function:CSK_MultiIOLinkSMI.writeMessagePortMessageName">writeMessagePortMessageName()</a></p>
+</li>
+<li>
 <p><a href="#API:Function:CSK_MultiIOLinkSMI.writeParameter">writeParameter()</a></p>
 </li>
 <li>
@@ -1211,6 +1243,9 @@ The following functions can be used for reading or writing data by selected inst
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnDataLoadedOnReboot">OnDataLoadedOnReboot</a></p>
 </li>
 <li>
+<p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewDeviceId">OnNewDeviceId</a></p>
+</li>
+<li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewDeviceIdentificationApplied">OnNewDeviceIdentificationApplied</a></p>
 </li>
 <li>
@@ -1233,6 +1268,9 @@ The following functions can be used for reading or writing data by selected inst
 </li>
 <li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewListProcessDataCondition">OnNewListProcessDataCondition</a></p>
+</li>
+<li>
+<p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId">OnNewNewDeviceDeviceId</a></p>
 </li>
 <li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceFirmwareVersion">OnNewNewDeviceFirmwareVersion</a></p>
@@ -1272,6 +1310,9 @@ The following functions can be used for reading or writing data by selected inst
 </li>
 <li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortEvent">OnNewPortEvent</a></p>
+</li>
+<li>
+<p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortInformation">OnNewPortInformation</a></p>
 </li>
 <li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnNewPortStatus">OnNewPortStatus</a></p>
@@ -1429,6 +1470,9 @@ The following functions can be used for reading or writing data by selected inst
 <li>
 <p><a href="#API:Event:CSK_MultiIOLinkSMI.OnUserLevelServiceActive">OnUserLevelServiceActive</a></p>
 </li>
+<li>
+<p><a href="#API:Event:CSK_MultiIOLinkSMI.readMessagePortMessageName">readMessagePortMessageName</a></p>
+</li>
 </ul>
 </div>
 </div>
@@ -1522,9 +1566,15 @@ The following functions can be used for reading or writing data by selected inst
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">instance</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonNewDeviceIdentification</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Json table containing the device identification.</p></td>
 </tr>
 </tbody>
@@ -1534,7 +1584,7 @@ The following functions can be used for reading or writing data by selected inst
 <h6 id="_sample_auto_generated_3">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.applyNewDeviceIdentification(jsonNewDeviceIdentification)</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.applyNewDeviceIdentification(instance, jsonNewDeviceIdentification)</code></pre>
 </div>
 </div>
 </div>
@@ -1574,6 +1624,28 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.copyReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyReadDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_sample_auto_generated_6">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.copyReadDataMessage()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.copyWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyWriteDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_sample_auto_generated_7">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.copyWriteDataMessage()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.createIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">createIODDReadMessage()</span></h5>
 <div class="sect5">
 <h6 id="_short_description_8">Short description</h6>
@@ -1582,7 +1654,7 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_6">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_8">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.createIODDReadMessage()</code></pre>
@@ -1599,7 +1671,7 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_7">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_9">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.createIODDWriteMessage()</code></pre>
@@ -1616,7 +1688,7 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_8">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_10">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.deleteIODDReadMessage()</code></pre>
@@ -1633,7 +1705,7 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_9">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_11">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.deleteIODDWriteMessage()</code></pre>
@@ -1642,9 +1714,51 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect4">
-<h5 id="API:Function:CSK_MultiIOLinkSMI.getDeviceIdentification"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceIdentification()</span></h5>
+<h5 id="API:Function:CSK_MultiIOLinkSMI.getDeviceConfig"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceConfig()</span></h5>
 <div class="sect5">
 <h6 id="_short_description_12">Short description</h6>
+
+</div>
+<div class="sect5">
+<h6 id="_return_values">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonCopiedDeviceConfig</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_12">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">jsonCopiedDeviceConfig = CSK_MultiIOLinkSMI.getDeviceConfig()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.getDeviceIdentification"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceIdentification()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_13">Short description</h6>
 <div class="paragraph">
 <p>Get identification of a device connected to a specified port. The identification contains the following parameters:<br>
 *statusInfo - status of the IO-Link port<br>
@@ -1686,7 +1800,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values">Return values</h6>
+<h6 id="_return_values_2">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1713,7 +1827,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_10">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_13">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonDeviceIdentification = CSK_MultiIOLinkSMI.getDeviceIdentification(port)</code></pre>
@@ -1724,7 +1838,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getInstanceParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstanceParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_13">Short description</h6>
+<h6 id="_short_description_14">Short description</h6>
 <div class="paragraph">
 <p>Get all parameters of the instance</p>
 </div>
@@ -1757,7 +1871,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_2">Return values</h6>
+<h6 id="_return_values_3">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1784,7 +1898,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_11">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_14">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonParameters = CSK_MultiIOLinkSMI.getInstanceParameters(instanceNo)</code></pre>
@@ -1793,15 +1907,57 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.getInstancePortMap"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancePortMap()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_15">Short description</h6>
+
+</div>
+<div class="sect5">
+<h6 id="_return_values_4">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonInstancePortMap</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_15">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">jsonInstancePortMap = CSK_MultiIOLinkSMI.getInstancePortMap()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getInstancesAmount"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancesAmount()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_14">Short description</h6>
+<h6 id="_short_description_16">Short description</h6>
 <div class="paragraph">
 <p>Get the amount of created instances of this module.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_3">Return values</h6>
+<h6 id="_return_values_5">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1828,7 +1984,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_12">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_16">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">amount = CSK_MultiIOLinkSMI.getInstancesAmount()</code></pre>
@@ -1839,7 +1995,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getIODDReadMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDReadMessageJSONTemplate()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_15">Short description</h6>
+<h6 id="_short_description_17">Short description</h6>
 <div class="paragraph">
 <p>Function to get the JSON template of the message that will be read from IO-Link device.</p>
 </div>
@@ -1872,7 +2028,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_4">Return values</h6>
+<h6 id="_return_values_6">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1899,7 +2055,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_13">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_17">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate = CSK_MultiIOLinkSMI.getIODDReadMessageJSONTemplate(messageName)</code></pre>
@@ -1910,7 +2066,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDWriteMessageJSONTemplate()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_16">Short description</h6>
+<h6 id="_short_description_18">Short description</h6>
 <div class="paragraph">
 <p>Function to get the JSON template of the message that is expected to be written to IO-Link device.</p>
 </div>
@@ -1943,7 +2099,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_5">Return values</h6>
+<h6 id="_return_values_7">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1970,7 +2126,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_14">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_18">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate = CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate(messageName)</code></pre>
@@ -1981,7 +2137,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_17">Short description</h6>
+<h6 id="_short_description_19">Short description</h6>
 <div class="paragraph">
 <p>Function to get all parameters of the client in JSON format.</p>
 </div>
@@ -2014,7 +2170,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_6">Return values</h6>
+<h6 id="_return_values_8">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2041,7 +2197,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_15">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_19">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonParameters = CSK_MultiIOLinkSMI.getParameters(instanceNo)</code></pre>
@@ -2052,13 +2208,13 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getPort()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_18">Short description</h6>
+<h6 id="_short_description_20">Short description</h6>
 <div class="paragraph">
 <p>Function to get port of currently selected instance.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_7">Return values</h6>
+<h6 id="_return_values_9">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2085,7 +2241,7 @@ The following functions can be used for reading or writing data by selected inst
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_16">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_20">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">port = CSK_MultiIOLinkSMI.getPort()</code></pre>
@@ -2096,7 +2252,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getReadDataResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getReadDataResultNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_19">Short description</h6>
+<h6 id="_short_description_21">Short description</h6>
 <div class="paragraph">
 <p>Get the latest result of readinig message.<br>
 NUM will be replaced by the number of instance (e.g. "getReadDataResult1").<br></p>
@@ -2104,128 +2260,6 @@ NUM will be replaced by the number of instance (e.g. "getReadDataResult1").<br><
 </div>
 <div class="sect5">
 <h6 id="_parameters_8">Parameters</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">messageName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the message to get the latest data about.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_return_values_8">Return values</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">latestSuccess</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Latest success of reading.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">jsonMessageContent</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Latest JSON table with received message content.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_17">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">latestSuccess, jsonMessageContent = CSK_MultiIOLinkSMI.getReadDataResultNUM(messageName)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Function:CSK_MultiIOLinkSMI.getStatusModuleActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getStatusModuleActive()</span></h5>
-<div class="sect5">
-<h6 id="_short_description_20">Short description</h6>
-<div class="paragraph">
-<p>Function to get status if module is active.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_return_values_9">Return values</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_18">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">status = CSK_MultiIOLinkSMI.getStatusModuleActive()</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Function:CSK_MultiIOLinkSMI.getWriteDataResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getWriteDataResultNUM()</span></h5>
-<div class="sect5">
-<h6 id="_short_description_21">Short description</h6>
-<div class="paragraph">
-<p>Get the latest result of writng message.<br>
-NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_parameters_9">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2270,6 +2304,128 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">latestSuccess</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Latest success of reading.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonMessageContent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Latest JSON table with received message content.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_21">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">latestSuccess, jsonMessageContent = CSK_MultiIOLinkSMI.getReadDataResultNUM(messageName)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.getStatusModuleActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getStatusModuleActive()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_22">Short description</h6>
+<div class="paragraph">
+<p>Function to get status if module is active.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_return_values_11">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_22">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">status = CSK_MultiIOLinkSMI.getStatusModuleActive()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.getWriteDataResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getWriteDataResultNUM()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_23">Short description</h6>
+<div class="paragraph">
+<p>Get the latest result of writng message.<br>
+NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_parameters_9">Parameters</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">messageName</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the message to get the latest data about.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_12">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
@@ -2285,7 +2441,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_19">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_23">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, jsonMessageContent = CSK_MultiIOLinkSMI.getWriteDataResultNUM(messageName)</code></pre>
@@ -2296,7 +2452,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.handleOnNewPortEvent"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">handleOnNewPortEvent()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_22">Short description</h6>
+<h6 id="_short_description_24">Short description</h6>
 <div class="paragraph">
 <p>Internally used function triggered when the new event occurs in IO-Link port.</p>
 </div>
@@ -2343,7 +2499,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_20">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_24">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.handleOnNewPortEvent(port, eventType, eventCode)</code></pre>
@@ -2354,13 +2510,13 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.loadParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">loadParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_23">Short description</h6>
+<h6 id="_short_description_25">Short description</h6>
 <div class="paragraph">
 <p>Load parameters for this module from the CSK_PersistentData module if possible and use them.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_11">Return values</h6>
+<h6 id="_return_values_13">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2387,7 +2543,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_21">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_25">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success = CSK_MultiIOLinkSMI.loadParameters()</code></pre>
@@ -2398,13 +2554,13 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.makeDefaultInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">makeDefaultInstance()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_24">Short description</h6>
+<h6 id="_short_description_26">Short description</h6>
 <div class="paragraph">
 <p>Set all instance parameters to default values.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_22">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_26">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.makeDefaultInstance()</code></pre>
@@ -2415,13 +2571,13 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.pageCalled"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pageCalled()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_25">Short description</h6>
+<h6 id="_short_description_27">Short description</h6>
 <div class="paragraph">
 <p>Function to register "OnResume" of the module UI (only as helper function).</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_12">Return values</h6>
+<h6 id="_return_values_14">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2448,7 +2604,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_23">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_27">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">empty = CSK_MultiIOLinkSMI.pageCalled()</code></pre>
@@ -2457,9 +2613,109 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.pasteReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteReadDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_return_values_15">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">processDataTableContent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">parameterTableContent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_28">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">processDataTableContent, parameterTableContent, jsonTemplate = CSK_MultiIOLinkSMI.pasteReadDataMessage()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.pasteWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteWriteDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_return_values_16">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">processDataTableContent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">parameterTableContent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_29">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">processDataTableContent, parameterTableContent, jsonTemplate = CSK_MultiIOLinkSMI.pasteWriteDataMessage()</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataInRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_26">Short description</h6>
+<h6 id="_short_description_28">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.processDataInRowSelected function when row in process data in of read message table is selected.</p>
 </div>
@@ -2492,7 +2748,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_24">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_30">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter(rowData)</code></pre>
@@ -2503,7 +2759,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.processDataOutRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataOutRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_27">Short description</h6>
+<h6 id="_short_description_29">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.processDataOutRowSelected function when row in process data out of write message table is selected.</p>
 </div>
@@ -2536,7 +2792,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_25">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_31">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.processDataOutRowSelectedCSKIODDInterpreter(rowData)</code></pre>
@@ -2547,7 +2803,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_28">Short description</h6>
+<h6 id="_short_description_30">Short description</h6>
 <div class="paragraph">
 <p>Read configured message from IO-Link sensor.</p>
 </div>
@@ -2580,7 +2836,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_13">Return values</h6>
+<h6 id="_return_values_17">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2613,7 +2869,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_26">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_32">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, jsonReceivedData = CSK_MultiIOLinkSMI.readIODDMessage(messageName)</code></pre>
@@ -2624,7 +2880,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessageNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessageNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_29">Short description</h6>
+<h6 id="_short_description_31">Short description</h6>
 <div class="paragraph">
 <p>Read preconfigured message.<br>
 NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
@@ -2658,7 +2914,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_14">Return values</h6>
+<h6 id="_return_values_18">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2691,7 +2947,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_27">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_33">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, jsonMessageContent = CSK_MultiIOLinkSMI.readIODDMessageNUM(messageName)</code></pre>
@@ -2702,13 +2958,13 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessageUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessageUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_30">Short description</h6>
+<h6 id="_short_description_32">Short description</h6>
 <div class="paragraph">
 <p>Read configured message from IO-Link sensor from UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_28">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_34">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.readIODDMessageUI()</code></pre>
@@ -2719,7 +2975,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_31">Short description</h6>
+<h6 id="_short_description_33">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
@@ -2758,7 +3014,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_15">Return values</h6>
+<h6 id="_return_values_19">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2791,7 +3047,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_29">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_35">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">readSuccess, readResult = CSK_MultiIOLinkSMI.readParameter(index, subindex)</code></pre>
@@ -2802,7 +3058,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_32">Short description</h6>
+<h6 id="_short_description_34">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor as a raw byte array. Might be useful for testing.  If reading failed, returns nil.</p>
 </div>
@@ -2841,7 +3097,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_16">Return values</h6>
+<h6 id="_return_values_20">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2868,7 +3124,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_30">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_36">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">resultByteArray = CSK_MultiIOLinkSMI.readParameterByteArray(index, subindex)</code></pre>
@@ -2879,7 +3135,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_33">Short description</h6>
+<h6 id="_short_description_35">Short description</h6>
 <div class="paragraph">
 <p>Read paramerter and return it as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -2922,7 +3178,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_17">Return values</h6>
+<h6 id="_return_values_21">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2949,7 +3205,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_31">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_37">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">byteArrayData = CSK_MultiIOLinkSMI.readParameterByteArray_NUM(index, subindex)</code></pre>
@@ -2960,13 +3216,13 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_34">Short description</h6>
+<h6 id="_short_description_36">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor as a raw byte array to show it in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_32">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_38">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.readParameterByteArrayUI()</code></pre>
@@ -2977,7 +3233,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_35">Short description</h6>
+<h6 id="_short_description_37">Short description</h6>
 <div class="paragraph">
 <p>Read parameter with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table.<br>
 NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br></p>
@@ -3023,7 +3279,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_18">Return values</h6>
+<h6 id="_return_values_22">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3050,7 +3306,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_33">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_39">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">jsonData = CSK_MultiIOLinkSMI.readParameterIODD_NUM(index, subindex, jsonDataPointInfo)</code></pre>
@@ -3061,7 +3317,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_36">Short description</h6>
+<h6 id="_short_description_38">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.readParameterRowSelected function when row in read parameters table of read message is selected.</p>
 </div>
@@ -3094,7 +3350,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_34">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_40">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.readParameterRowSelectedCSKIODDInterpreter(rowData)</code></pre>
@@ -3105,13 +3361,13 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessData"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessData()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_37">Short description</h6>
+<h6 id="_short_description_39">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_19">Return values</h6>
+<h6 id="_return_values_23">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3144,7 +3400,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_35">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_41">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">readSuccess, readResult = CSK_MultiIOLinkSMI.readProcessData()</code></pre>
@@ -3155,13 +3411,13 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_38">Short description</h6>
+<h6 id="_short_description_40">Short description</h6>
 <div class="paragraph">
 <p>Read process data of IO-Link sensor as a raw byte array. Might be useful for testing. If reading failed, returns nil.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_20">Return values</h6>
+<h6 id="_return_values_24">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3188,7 +3444,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_36">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_42">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">resultByteArray = CSK_MultiIOLinkSMI.readProcessDataByteArray()</code></pre>
@@ -3199,7 +3455,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_39">Short description</h6>
+<h6 id="_short_description_41">Short description</h6>
 <div class="paragraph">
 <p>Read process data and return it as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -3209,7 +3465,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values_21">Return values</h6>
+<h6 id="_return_values_25">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3236,7 +3492,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_37">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_43">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">byteArrayData = CSK_MultiIOLinkSMI.readProcessDataByteArray_NUM()</code></pre>
@@ -3247,13 +3503,13 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_40">Short description</h6>
+<h6 id="_short_description_42">Short description</h6>
 <div class="paragraph">
 <p>Read process data of IO-Link sensor as a raw byte array to show it in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_38">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_44">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.readProcessDataByteArrayUI()</code></pre>
@@ -3264,7 +3520,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_41">Short description</h6>
+<h6 id="_short_description_43">Short description</h6>
 <div class="paragraph">
 <p>Read process data with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table.<br>
 NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</p>
@@ -3298,7 +3554,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_22">Return values</h6>
+<h6 id="_return_values_26">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3325,7 +3581,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_39">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_45">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">convertedResult = CSK_MultiIOLinkSMI.readProcessDataIODD_NUM(jsonDataPointInfo)</code></pre>
@@ -3336,13 +3592,13 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.refreshReadDataResult"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">refreshReadDataResult()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_42">Short description</h6>
+<h6 id="_short_description_44">Short description</h6>
 <div class="paragraph">
 <p>Function to show the latest read result of the selected message in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_40">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_46">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.refreshReadDataResult()</code></pre>
@@ -3353,13 +3609,13 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.refreshWriteDataResult"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">refreshWriteDataResult()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_43">Short description</h6>
+<h6 id="_short_description_45">Short description</h6>
 <div class="paragraph">
 <p>Function to show the latest write result of the selected message in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_41">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_47">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.refreshWriteDataResult()</code></pre>
@@ -3370,14 +3626,14 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.resetInstances"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">resetInstances()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_44">Short description</h6>
+<h6 id="_short_description_46">Short description</h6>
 <div class="paragraph">
 <p>Function to reset instances to one single instance.<br>
 IMPORTANT: As instances start their own threads, the module needs to be restarted if new instances are needed&#8230;&#8203; (see AppEngine docu for "Script.startScript").</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_42">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_48">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.resetInstances()</code></pre>
@@ -3388,13 +3644,13 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.resetModule"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">resetModule()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_45">Short description</h6>
+<h6 id="_short_description_47">Short description</h6>
 <div class="paragraph">
 <p>Function to reset main configuration of module.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_43">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_49">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.resetModule()</code></pre>
@@ -3405,7 +3661,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.sendParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">sendParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_46">Short description</h6>
+<h6 id="_short_description_48">Short description</h6>
 <div class="paragraph">
 <p>Send parameters to CSK_PersistentData module if possible to save them.</p>
 </div>
@@ -3438,7 +3694,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_44">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_50">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.sendParameters(noDataSave)</code></pre>
@@ -3449,7 +3705,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setFlowConfigPriority"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setFlowConfigPriority()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_47">Short description</h6>
+<h6 id="_short_description_49">Short description</h6>
 <div class="paragraph">
 <p>Function to configure if FlowConfig should have priority for FlowConfig relevant configuration.</p>
 </div>
@@ -3482,7 +3738,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_45">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_51">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setFlowConfigPriority(status)</code></pre>
@@ -3493,7 +3749,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setIODDReadMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setIODDReadMessageName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_48">Short description</h6>
+<h6 id="_short_description_50">Short description</h6>
 <div class="paragraph">
 <p>Set title of the message to read from IO-Link device.</p>
 </div>
@@ -3526,7 +3782,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_46">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_52">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setIODDReadMessageName(newName)</code></pre>
@@ -3537,7 +3793,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setIODDWriteMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setIODDWriteMessageName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_49">Short description</h6>
+<h6 id="_short_description_51">Short description</h6>
 <div class="paragraph">
 <p>Set title of the message to write to IO-Link device.</p>
 </div>
@@ -3570,7 +3826,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_47">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_53">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setIODDWriteMessageName(newName)</code></pre>
@@ -3581,7 +3837,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setLoadOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setLoadOnReboot()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_50">Short description</h6>
+<h6 id="_short_description_52">Short description</h6>
 <div class="paragraph">
 <p>Configure if this module should load its saved parameters at app/ device boot up.</p>
 </div>
@@ -3614,7 +3870,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_48">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_54">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setLoadOnReboot(status)</code></pre>
@@ -3625,7 +3881,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setParameterByteArrayToWrite"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setParameterByteArrayToWrite()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_51">Short description</h6>
+<h6 id="_short_description_53">Short description</h6>
 <div class="paragraph">
 <p>Set byte array to write to the parameter of the device for testing purposes in UI.</p>
 </div>
@@ -3658,7 +3914,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_49">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_55">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setParameterByteArrayToWrite(byteArrayToWrite)</code></pre>
@@ -3669,7 +3925,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setParameterName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setParameterName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_52">Short description</h6>
+<h6 id="_short_description_54">Short description</h6>
 <div class="paragraph">
 <p>Function to set the name of the parameters if saved/loaded via the CSK_PersistentData module.</p>
 </div>
@@ -3702,7 +3958,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_50">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_56">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setParameterName(name)</code></pre>
@@ -3713,7 +3969,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setPort()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_53">Short description</h6>
+<h6 id="_short_description_55">Short description</h6>
 <div class="paragraph">
 <p>Set an IO-Link port for selected instance.</p>
 </div>
@@ -3746,7 +4002,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_51">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_57">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setPort(port)</code></pre>
@@ -3757,7 +4013,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setProcessDataByteArrayToWrite"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setProcessDataByteArrayToWrite()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_54">Short description</h6>
+<h6 id="_short_description_56">Short description</h6>
 <div class="paragraph">
 <p>Set byte array to write to the process data of the device for testing purposes in UI.</p>
 </div>
@@ -3790,7 +4046,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_52">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_58">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setProcessDataByteArrayToWrite(processDataByteArray)</code></pre>
@@ -3801,7 +4057,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setProcessDataCondition()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_55">Short description</h6>
+<h6 id="_short_description_57">Short description</h6>
 <div class="paragraph">
 <p>Set process data structure varient if the structure is variable. The respective value will be sent to the parameter responsible for the structure.</p>
 </div>
@@ -3834,7 +4090,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_53">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_59">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setProcessDataCondition(newCondition)</code></pre>
@@ -3845,7 +4101,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedInstance()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_56">Short description</h6>
+<h6 id="_short_description_58">Short description</h6>
 <div class="paragraph">
 <p>Select one of the multiple instances.</p>
 </div>
@@ -3878,7 +4134,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_54">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_60">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setSelectedInstance(instance)</code></pre>
@@ -3889,7 +4145,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedIODDReadMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_57">Short description</h6>
+<h6 id="_short_description_59">Short description</h6>
 <div class="paragraph">
 <p>Select a read message to edit.</p>
 </div>
@@ -3922,7 +4178,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_55">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_61">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setSelectedIODDReadMessage(newSelectedMessage)</code></pre>
@@ -3933,7 +4189,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedIODDWriteMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_58">Short description</h6>
+<h6 id="_short_description_60">Short description</h6>
 <div class="paragraph">
 <p>Select a write message to edit.</p>
 </div>
@@ -3966,7 +4222,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_56">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_62">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setSelectedIODDWriteMessage(newSelectedMessage)</code></pre>
@@ -3977,7 +4233,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedTab"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedTab()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_59">Short description</h6>
+<h6 id="_short_description_61">Short description</h6>
 <div class="paragraph">
 <p>Select tab in UI.</p>
 </div>
@@ -4010,7 +4266,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_57">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_63">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setSelectedTab(tabNumber)</code></pre>
@@ -4021,7 +4277,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestReadParameterIndex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestReadParameterIndex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_60">Short description</h6>
+<h6 id="_short_description_62">Short description</h6>
 <div class="paragraph">
 <p>Set index of the parameter to read as byte array in UI.</p>
 </div>
@@ -4054,7 +4310,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_58">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_64">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTestReadParameterIndex(index)</code></pre>
@@ -4065,7 +4321,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestReadParameterSubindex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestReadParameterSubindex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_61">Short description</h6>
+<h6 id="_short_description_63">Short description</h6>
 <div class="paragraph">
 <p>Set subindex of the parameter to read as byte array in UI.</p>
 </div>
@@ -4098,7 +4354,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_59">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_65">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTestReadParameterSubindex(subindex)</code></pre>
@@ -4109,7 +4365,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_62">Short description</h6>
+<h6 id="_short_description_64">Short description</h6>
 <div class="paragraph">
 <p>Set JSON content of message to write to device. The content must have the same format as JSON template of the selected message (template is generated based on selected paramters/process data).</p>
 </div>
@@ -4142,7 +4398,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_60">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_66">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTestWriteIODDMessage(newTestWriteIODDMessage)</code></pre>
@@ -4153,7 +4409,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteParameterIndex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteParameterIndex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_63">Short description</h6>
+<h6 id="_short_description_65">Short description</h6>
 <div class="paragraph">
 <p>Set index of the parameter to write as byte array in UI.</p>
 </div>
@@ -4186,7 +4442,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_61">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_67">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTestWriteParameterIndex(index)</code></pre>
@@ -4197,7 +4453,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteParameterSubindex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteParameterSubindex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_64">Short description</h6>
+<h6 id="_short_description_66">Short description</h6>
 <div class="paragraph">
 <p>Set subindex of the parameter to write as byte array in UI.</p>
 </div>
@@ -4230,7 +4486,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_62">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_68">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTestWriteParameterSubindex(subindex)</code></pre>
@@ -4241,7 +4497,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTriggerType"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTriggerType()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_65">Short description</h6>
+<h6 id="_short_description_67">Short description</h6>
 <div class="paragraph">
 <p>Set condition of when to read the selected read message. Possible options:<br>
 *Periodic - the message is periodically requested from the IO-Link device. The period can be set by setTriggerValue function.<br>
@@ -4276,7 +4532,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_63">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_69">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTriggerType(newTriggerType)</code></pre>
@@ -4287,7 +4543,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTriggerValue"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTriggerValue()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_66">Short description</h6>
+<h6 id="_short_description_68">Short description</h6>
 <div class="paragraph">
 <p>Set value depending on the selected trigger type of the selected read message.<br>
 *if type is 'Periodic' - period in [ms].<br>
@@ -4322,7 +4578,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_64">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_70">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.setTriggerValue(newTriggerValue)</code></pre>
@@ -4333,7 +4589,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.updateInstanceParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">updateInstanceParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_67">Short description</h6>
+<h6 id="_short_description_69">Short description</h6>
 <div class="paragraph">
 <p>Update all parameters of specified instance. Following is sample structure of JSON table with parameters:<br></p>
 </div>
@@ -4414,7 +4670,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_65">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_71">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.updateInstanceParameters(jsonNewParameters)</code></pre>
@@ -4425,7 +4681,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.uploadFinishedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">uploadFinishedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_68">Short description</h6>
+<h6 id="_short_description_70">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.uploadFinished function when IODD file upload is finished.</p>
 </div>
@@ -4458,7 +4714,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_66">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_72">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.uploadFinishedCSKIODDInterpreter(uploadSuccess)</code></pre>
@@ -4469,7 +4725,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_69">Short description</h6>
+<h6 id="_short_description_71">Short description</h6>
 <div class="paragraph">
 <p>Write configured message to IO-Link sensor.</p>
 </div>
@@ -4508,7 +4764,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_23">Return values</h6>
+<h6 id="_return_values_27">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4535,7 +4791,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_67">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_73">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success = CSK_MultiIOLinkSMI.writeIODDMessage(messageName, jsonDataToWrite)</code></pre>
@@ -4546,13 +4802,13 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessageFromUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageFromUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_70">Short description</h6>
+<h6 id="_short_description_72">Short description</h6>
 <div class="paragraph">
 <p>Write configured message to IO-Link sensor from UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_68">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_74">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.writeIODDMessageFromUI()</code></pre>
@@ -4563,7 +4819,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessageNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_71">Short description</h6>
+<h6 id="_short_description_73">Short description</h6>
 <div class="paragraph">
 <p>Write preconfigured message.<br>
 NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
@@ -4603,7 +4859,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_24">Return values</h6>
+<h6 id="_return_values_28">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4636,7 +4892,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_69">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_75">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, details = CSK_MultiIOLinkSMI.writeIODDMessageNUM(messageName, jsonDataToWrite)</code></pre>
@@ -4645,15 +4901,104 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Function:CSK_MultiIOLinkSMI.writeMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeMessagePortMessageName()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_74">Short description</h6>
+<div class="paragraph">
+<p>Function to write the message with to IOLink device. The data must a JSON object that has the same structure as the configured message. Port - sensor port the device is connected to (S1,S2 &#8230;&#8203;). MessageName - the configured name of the message.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_parameters_46">Parameters</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">data</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object that has the same structure as the configured message.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_29">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Success of writing data.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">queueSize</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Size of the queue calls in the thread responsible for communication with this IOLink device. If the queue builds up, this can lead to memory overflow. That&#8217;s why the queue is recet to 0 in case there are more than 10 calls.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">time</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Time in milliseconds spent for getting and parsing the data.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">errorMessage</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Error message, if any.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_76">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua">success, queueSize, time, errorMessage = CSK_MultiIOLinkSMI.writeMessagePortMessageName(data)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_72">Short description</h6>
+<h6 id="_short_description_75">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_46">Parameters</h6>
+<h6 id="_parameters_47">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4692,7 +5037,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_25">Return values</h6>
+<h6 id="_return_values_30">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4719,7 +5064,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_70">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_77">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">writeSuccess = CSK_MultiIOLinkSMI.writeParameter(index, subindex, jsonDataToWrite)</code></pre>
@@ -4730,13 +5075,13 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_73">Short description</h6>
+<h6 id="_short_description_76">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link sensor as a raw byte array. Might be useful for testing.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_47">Parameters</h6>
+<h6 id="_parameters_48">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4775,7 +5120,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_26">Return values</h6>
+<h6 id="_return_values_31">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4808,7 +5153,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_71">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_78">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, errorDescription = CSK_MultiIOLinkSMI.writeParameterByteArray(index, subindex, byteArrayToWrite)</code></pre>
@@ -4819,7 +5164,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_74">Short description</h6>
+<h6 id="_short_description_77">Short description</h6>
 <div class="paragraph">
 <p>Write parameter as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -4829,7 +5174,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_48">Parameters</h6>
+<h6 id="_parameters_49">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4868,7 +5213,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_27">Return values</h6>
+<h6 id="_return_values_32">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4901,7 +5246,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_72">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_79">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, details = CSK_MultiIOLinkSMI.writeParameterByteArray_NUM(index, subindex, jsonDataToWrite)</code></pre>
@@ -4912,13 +5257,13 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_75">Short description</h6>
+<h6 id="_short_description_78">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link device as a raw byte array triggered by button in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_73">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_80">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.writeParameterByteArrayUI()</code></pre>
@@ -4929,14 +5274,14 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_76">Short description</h6>
+<h6 id="_short_description_79">Short description</h6>
 <div class="paragraph">
 <p>Write parameter with provided info from IODD interpreter and data to write (as JSON tables).<br>
 NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_49">Parameters</h6>
+<h6 id="_parameters_50">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4981,7 +5326,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_28">Return values</h6>
+<h6 id="_return_values_33">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5014,7 +5359,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_74">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_81">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, details = CSK_MultiIOLinkSMI.writeParameterIODD_NUM(index, subindex, jsonDataPointInfo, jsonDataToWrite)</code></pre>
@@ -5025,13 +5370,13 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_77">Short description</h6>
+<h6 id="_short_description_80">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.writeParameterRowSelected function when row in write parameters table of write message is selected.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_50">Parameters</h6>
+<h6 id="_parameters_51">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5058,7 +5403,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_75">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_82">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.writeParameterRowSelectedCSKIODDInterpreter(rowData)</code></pre>
@@ -5069,13 +5414,13 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessData"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessData()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_78">Short description</h6>
+<h6 id="_short_description_81">Short description</h6>
 <div class="paragraph">
 <p>Write process data to IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_51">Parameters</h6>
+<h6 id="_parameters_52">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5102,7 +5447,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_29">Return values</h6>
+<h6 id="_return_values_34">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5129,7 +5474,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_76">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_83">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">writeSuccess = CSK_MultiIOLinkSMI.writeProcessData(jsonDataToWrite)</code></pre>
@@ -5140,13 +5485,13 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_79">Short description</h6>
+<h6 id="_short_description_82">Short description</h6>
 <div class="paragraph">
 <p>Write process data to IO-Link sensor as a raw byte array. Might be useful for testing.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_52">Parameters</h6>
+<h6 id="_parameters_53">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5173,7 +5518,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_30">Return values</h6>
+<h6 id="_return_values_35">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5206,7 +5551,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_77">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_84">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, errorDescription = CSK_MultiIOLinkSMI.writeProcessDataByteArray(byteArrayToWrite)</code></pre>
@@ -5217,7 +5562,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_80">Short description</h6>
+<h6 id="_short_description_83">Short description</h6>
 <div class="paragraph">
 <p>Write process data as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -5227,7 +5572,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_53">Parameters</h6>
+<h6 id="_parameters_54">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5254,7 +5599,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_31">Return values</h6>
+<h6 id="_return_values_36">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5287,7 +5632,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_78">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_85">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, details = CSK_MultiIOLinkSMI.writeProcessDataByteArray_NUM(jsonData)</code></pre>
@@ -5298,7 +5643,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_sample_auto_generated_79">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_86">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">CSK_MultiIOLinkSMI.writeProcessDataByteArrayUI()</code></pre>
@@ -5309,14 +5654,14 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_81">Short description</h6>
+<h6 id="_short_description_84">Short description</h6>
 <div class="paragraph">
 <p>Write process data with provided info from IODD interpreter and data to write (as JSON tables).<br>
 NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_54">Parameters</h6>
+<h6 id="_parameters_55">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5349,7 +5694,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").<
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_32">Return values</h6>
+<h6 id="_return_values_37">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5382,7 +5727,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").<
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_80">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_87">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success, details = CSK_MultiIOLinkSMI.writeProcessDataIODD_NUM(jsonDataPointInfo, jsonData)</code></pre>
@@ -5396,13 +5741,13 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").<
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnDataLoadedOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnDataLoadedOnReboot</span></h5>
 <div class="sect5">
-<h6 id="_short_description_82">Short description</h6>
+<h6 id="_short_description_85">Short description</h6>
 <div class="paragraph">
 <p>Event to call if module tried to load parameters and should be ready.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_81">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_88">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnDataLoadedOnReboot</span>()
@@ -5415,15 +5760,57 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceId</span></h5>
+<div class="sect5">
+<h6 id="_callback_arguments">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">deviceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_89">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewDeviceId</span>(deviceId)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewDeviceId</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewDeviceId</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewDeviceIdentificationApplied"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceIdentificationApplied</span></h5>
 <div class="sect5">
-<h6 id="_short_description_83">Short description</h6>
+<h6 id="_short_description_86">Short description</h6>
 <div class="paragraph">
 <p>Notify if device identification of new discovered device is applied instead of the old one.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments">Callback arguments</h6>
+<h6 id="_callback_arguments_2">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5456,7 +5843,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_82">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_90">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewDeviceIdentificationApplied</span>(instance, jsonInstanceParameters)
@@ -5471,13 +5858,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewFirmwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_84">Short description</h6>
+<h6 id="_short_description_87">Short description</h6>
 <div class="paragraph">
 <p>Event to show the firmware version of the device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_2">Callback arguments</h6>
+<h6 id="_callback_arguments_3">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5504,7 +5891,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_83">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_91">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewFirmwareVersion</span>(firmwareVersion)
@@ -5519,13 +5906,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewHardwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_85">Short description</h6>
+<h6 id="_short_description_88">Short description</h6>
 <div class="paragraph">
 <p>Event to show the hardware version of the device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_3">Callback arguments</h6>
+<h6 id="_callback_arguments_4">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5552,7 +5939,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_84">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_92">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewHardwareVersion</span>(hardwareVersion)
@@ -5567,13 +5954,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewInstanceList"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewInstanceList</span></h5>
 <div class="sect5">
-<h6 id="_short_description_86">Short description</h6>
+<h6 id="_short_description_89">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created instances</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_4">Callback arguments</h6>
+<h6 id="_callback_arguments_5">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5600,7 +5987,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_85">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_93">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewInstanceList</span>(list)
@@ -5615,13 +6002,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewIOLinkPortStatus"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewIOLinkPortStatus</span></h5>
 <div class="sect5">
-<h6 id="_short_description_87">Short description</h6>
+<h6 id="_short_description_90">Short description</h6>
 <div class="paragraph">
 <p>Notify new status of the IO-Link port.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_5">Callback arguments</h6>
+<h6 id="_callback_arguments_6">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5654,7 +6041,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_86">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_94">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewIOLinkPortStatus</span>(instance, status)
@@ -5669,13 +6056,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListIODDReadMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDReadMessages</span></h5>
 <div class="sect5">
-<h6 id="_short_description_88">Short description</h6>
+<h6 id="_short_description_91">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created read messages.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_6">Callback arguments</h6>
+<h6 id="_callback_arguments_7">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5702,7 +6089,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_87">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_95">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewListIODDReadMessages</span>(jsonList)
@@ -5717,13 +6104,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListIODDWriteMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDWriteMessages</span></h5>
 <div class="sect5">
-<h6 id="_short_description_89">Short description</h6>
+<h6 id="_short_description_92">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created write messages.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_7">Callback arguments</h6>
+<h6 id="_callback_arguments_8">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5750,7 +6137,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_88">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_96">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewListIODDWriteMessages</span>(jsonList)
@@ -5765,13 +6152,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListProcessDataCondition</span></h5>
 <div class="sect5">
-<h6 id="_short_description_90">Short description</h6>
+<h6 id="_short_description_93">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of process data structure options.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_8">Callback arguments</h6>
+<h6 id="_callback_arguments_9">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5798,7 +6185,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_89">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_97">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewListProcessDataCondition</span>(jsonListProcessDataCondition)
@@ -5811,15 +6198,57 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceDeviceId</span></h5>
+<div class="sect5">
+<h6 id="_callback_arguments_10">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">deviceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_98">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceDeviceId</span>(deviceId)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewNewDeviceDeviceId</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceFirmwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_91">Short description</h6>
+<h6 id="_short_description_94">Short description</h6>
 <div class="paragraph">
 <p>Event to show the firmware version of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_9">Callback arguments</h6>
+<h6 id="_callback_arguments_11">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5846,7 +6275,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_90">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_99">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceFirmwareVersion</span>(firmwareVersion)
@@ -5861,13 +6290,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceHardwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_92">Short description</h6>
+<h6 id="_short_description_95">Short description</h6>
 <div class="paragraph">
 <p>Event to show the hardware version of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_10">Callback arguments</h6>
+<h6 id="_callback_arguments_12">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5894,7 +6323,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_91">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_100">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceHardwareVersion</span>(hardwareVersion)
@@ -5909,13 +6338,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_93">Short description</h6>
+<h6 id="_short_description_96">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product id of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_11">Callback arguments</h6>
+<h6 id="_callback_arguments_13">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5942,7 +6371,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_92">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_101">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceProductId</span>(productId)
@@ -5957,13 +6386,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_94">Short description</h6>
+<h6 id="_short_description_97">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product name of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_12">Callback arguments</h6>
+<h6 id="_callback_arguments_14">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5990,7 +6419,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_93">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_102">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceProductName</span>(productName)
@@ -6005,13 +6434,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_95">Short description</h6>
+<h6 id="_short_description_98">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product text of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_13">Callback arguments</h6>
+<h6 id="_callback_arguments_15">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6038,7 +6467,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_94">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_103">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceProductText</span>(productText)
@@ -6053,13 +6482,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceSerialNumber"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceSerialNumber</span></h5>
 <div class="sect5">
-<h6 id="_short_description_96">Short description</h6>
+<h6 id="_short_description_99">Short description</h6>
 <div class="paragraph">
 <p>Event to show the serial number of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_14">Callback arguments</h6>
+<h6 id="_callback_arguments_16">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6086,7 +6515,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_95">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_104">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceSerialNumber</span>(serialNumber)
@@ -6101,13 +6530,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_97">Short description</h6>
+<h6 id="_short_description_100">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor ID of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_15">Callback arguments</h6>
+<h6 id="_callback_arguments_17">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6134,7 +6563,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_96">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_105">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceVendorId</span>(vendorId)
@@ -6149,13 +6578,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_98">Short description</h6>
+<h6 id="_short_description_101">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor name of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_16">Callback arguments</h6>
+<h6 id="_callback_arguments_18">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6182,7 +6611,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_97">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_106">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceVendorName</span>(vendorName)
@@ -6197,13 +6626,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_99">Short description</h6>
+<h6 id="_short_description_102">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor text of new discovered device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_17">Callback arguments</h6>
+<h6 id="_callback_arguments_19">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6230,7 +6659,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_98">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_107">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewNewDeviceVendorText</span>(vendorText)
@@ -6245,13 +6674,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewParameterName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewParameterName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_100">Short description</h6>
+<h6 id="_short_description_103">Short description</h6>
 <div class="paragraph">
 <p>Notify name of persistent data parameter.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_18">Callback arguments</h6>
+<h6 id="_callback_arguments_20">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6278,7 +6707,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_99">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_108">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewParameterName</span>(name)
@@ -6293,13 +6722,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPort</span></h5>
 <div class="sect5">
-<h6 id="_short_description_101">Short description</h6>
+<h6 id="_short_description_104">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected IO-Link port in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_19">Callback arguments</h6>
+<h6 id="_callback_arguments_21">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6326,7 +6755,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_100">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_109">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewPort</span>(Port)
@@ -6341,13 +6770,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortDropdown"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortDropdown</span></h5>
 <div class="sect5">
-<h6 id="_short_description_102">Short description</h6>
+<h6 id="_short_description_105">Short description</h6>
 <div class="paragraph">
 <p>Event to show list of ports in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_20">Callback arguments</h6>
+<h6 id="_callback_arguments_22">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6374,7 +6803,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_101">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_110">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewPortDropdown</span>(PortDropdown)
@@ -6389,13 +6818,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortEvent"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortEvent</span></h5>
 <div class="sect5">
-<h6 id="_short_description_103">Short description</h6>
+<h6 id="_short_description_106">Short description</h6>
 <div class="paragraph">
 <p>Event to show the new status of active IO-Link port. Can be used externally.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_21">Callback arguments</h6>
+<h6 id="_callback_arguments_23">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6436,7 +6865,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_102">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_111">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewPortEvent</span>(port, eventType, eventDescription)
@@ -6449,15 +6878,87 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 </div>
 <div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortInformation"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortInformation</span></h5>
+<div class="sect5">
+<h6 id="_callback_arguments_24">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">instanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">portNumber</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">portStatus</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonDeviceIdentification</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ioddName</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jsonNewDeviceIdentification</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_112">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewPortInformation</span>(instanceId, portNumber, portStatus, jsonDeviceIdentification, ioddName, jsonNewDeviceIdentification)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewPortInformation</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewPortInformation</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortStatus"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortStatus</span></h5>
 <div class="sect5">
-<h6 id="_short_description_104">Short description</h6>
+<h6 id="_short_description_107">Short description</h6>
 <div class="paragraph">
 <p>Event to show current port status of selected IO-Link port in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_22">Callback arguments</h6>
+<h6 id="_callback_arguments_25">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6484,7 +6985,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_103">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_113">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewPortStatus</span>(postStatus)
@@ -6499,13 +7000,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataCondition</span></h5>
 <div class="sect5">
-<h6 id="_short_description_105">Short description</h6>
+<h6 id="_short_description_108">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected IO-Link procecss data option of connected device in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_23">Callback arguments</h6>
+<h6 id="_callback_arguments_26">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6532,7 +7033,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_104">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_114">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProcessDataCondition</span>(condition)
@@ -6547,13 +7048,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataInTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataInTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_106">Short description</h6>
+<h6 id="_short_description_109">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewProcessDataInTableContent event to fill the process data in table of the read message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_24">Callback arguments</h6>
+<h6 id="_callback_arguments_27">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6580,7 +7081,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_105">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_115">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProcessDataInTableContentCSKIODDInterpreter</span>(tableContent)
@@ -6595,13 +7096,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataOutTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataOutTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_107">Short description</h6>
+<h6 id="_short_description_110">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewProcessDataOutTableContent event to fill the process data out table of the write message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_25">Callback arguments</h6>
+<h6 id="_callback_arguments_28">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6628,7 +7129,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_106">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_116">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProcessDataOutTableContentCSKIODDInterpreter</span>(tableContent)
@@ -6643,13 +7144,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessingParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessingParameter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_108">Short description</h6>
+<h6 id="_short_description_111">Short description</h6>
 <div class="paragraph">
 <p>Event to share processing parameters to the instances.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_26">Callback arguments</h6>
+<h6 id="_callback_arguments_29">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6694,7 +7195,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_107">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_117">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProcessingParameter</span>(objectNo, parameter, value, internalObjectNo)
@@ -6709,13 +7210,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_109">Short description</h6>
+<h6 id="_short_description_112">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product id of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_27">Callback arguments</h6>
+<h6 id="_callback_arguments_30">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6742,7 +7243,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_108">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_118">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProductId</span>(productId)
@@ -6757,13 +7258,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_110">Short description</h6>
+<h6 id="_short_description_113">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product name of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_28">Callback arguments</h6>
+<h6 id="_callback_arguments_31">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6790,7 +7291,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_109">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_119">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProductName</span>(productName)
@@ -6805,13 +7306,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_111">Short description</h6>
+<h6 id="_short_description_114">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product text of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_29">Callback arguments</h6>
+<h6 id="_callback_arguments_32">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6838,7 +7339,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_110">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_120">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewProductText</span>(productText)
@@ -6853,13 +7354,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadDataMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_112">Short description</h6>
+<h6 id="_short_description_115">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received message after the refresh button has been pressed in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_30">Callback arguments</h6>
+<h6 id="_callback_arguments_33">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6886,7 +7387,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_111">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_121">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadDataMessage</span>(message)
@@ -6901,13 +7402,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadDataSuccess"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadDataSuccess</span></h5>
 <div class="sect5">
-<h6 id="_short_description_113">Short description</h6>
+<h6 id="_short_description_116">Short description</h6>
 <div class="paragraph">
 <p>Event to show the success of reading message after the refresh button has been pressed in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_31">Callback arguments</h6>
+<h6 id="_callback_arguments_34">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6934,7 +7435,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_112">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_122">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadDataSuccess</span>(success)
@@ -6949,13 +7450,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadJSONTemplate</span></h5>
 <div class="sect5">
-<h6 id="_short_description_114">Short description</h6>
+<h6 id="_short_description_117">Short description</h6>
 <div class="paragraph">
 <p>Event to show JSON template of configured reading message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_32">Callback arguments</h6>
+<h6 id="_callback_arguments_35">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6982,7 +7483,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_113">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_123">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadJSONTemplate</span>(readJSONTemplate)
@@ -6997,13 +7498,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadMessageEventName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadMessageEventName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_115">Short description</h6>
+<h6 id="_short_description_118">Short description</h6>
 <div class="paragraph">
 <p>Event to show the event name that can be used externally.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_33">Callback arguments</h6>
+<h6 id="_callback_arguments_36">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7030,7 +7531,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_114">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_124">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadMessageEventName</span>(eventName)
@@ -7045,13 +7546,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadParameterByteArray</span></h5>
 <div class="sect5">
-<h6 id="_short_description_116">Short description</h6>
+<h6 id="_short_description_119">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received byte array after reading the configured parameter from IO-Link device for testing purposes.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_34">Callback arguments</h6>
+<h6 id="_callback_arguments_37">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7078,7 +7579,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_115">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_125">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadParameterByteArray</span>(receivedByteArray)
@@ -7093,13 +7594,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadParametersTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadParametersTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_117">Short description</h6>
+<h6 id="_short_description_120">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewReadParametersTableContent event to fill the paramters table of the read message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_35">Callback arguments</h6>
+<h6 id="_callback_arguments_38">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7126,7 +7627,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_116">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_126">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadParametersTableContentCSKIODDInterpreter</span>(tableContent)
@@ -7141,13 +7642,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadProcessDataByteArray</span></h5>
 <div class="sect5">
-<h6 id="_short_description_118">Short description</h6>
+<h6 id="_short_description_121">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received byte array after reading the process data from IO-Link device for testing purposes.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_36">Callback arguments</h6>
+<h6 id="_callback_arguments_39">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7174,7 +7675,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_117">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_127">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewReadProcessDataByteArray</span>(processDataByteArray)
@@ -7189,7 +7690,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewResultNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_119">Short description</h6>
+<h6 id="_short_description_122">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to provide result of instance.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewResult1").<br>
@@ -7197,7 +7698,7 @@ INFO: Other modules can check via "Script.isServedAsEvent" if event of sepecific
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_37">Callback arguments</h6>
+<h6 id="_callback_arguments_40">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7224,7 +7725,7 @@ INFO: Other modules can check via "Script.isServedAsEvent" if event of sepecific
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_118">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_128">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewResultNUM</span>(result)
@@ -7239,13 +7740,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedInstance</span></h5>
 <div class="sect5">
-<h6 id="_short_description_120">Short description</h6>
+<h6 id="_short_description_123">Short description</h6>
 <div class="paragraph">
 <p>Notify if new instance is selected.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_38">Callback arguments</h6>
+<h6 id="_callback_arguments_41">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7272,7 +7773,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_119">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_129">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSelectedInstance</span>(selectedObject)
@@ -7287,13 +7788,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedIODDReadMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_121">Short description</h6>
+<h6 id="_short_description_124">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected read message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_39">Callback arguments</h6>
+<h6 id="_callback_arguments_42">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7320,7 +7821,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_120">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_130">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSelectedIODDReadMessage</span>(messageName)
@@ -7335,13 +7836,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedIODDWriteMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_122">Short description</h6>
+<h6 id="_short_description_125">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected write message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_40">Callback arguments</h6>
+<h6 id="_callback_arguments_43">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7368,7 +7869,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_121">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_131">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSelectedIODDWriteMessage</span>(messageName)
@@ -7383,13 +7884,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedTab"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedTab</span></h5>
 <div class="sect5">
-<h6 id="_short_description_123">Short description</h6>
+<h6 id="_short_description_126">Short description</h6>
 <div class="paragraph">
 <p>Notify to show selected tab.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_41">Callback arguments</h6>
+<h6 id="_callback_arguments_44">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7416,7 +7917,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_122">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_132">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSelectedTab</span>(tabNumber)
@@ -7431,13 +7932,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSerialNumber"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSerialNumber</span></h5>
 <div class="sect5">
-<h6 id="_short_description_124">Short description</h6>
+<h6 id="_short_description_127">Short description</h6>
 <div class="paragraph">
 <p>Event to show the serial number of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_42">Callback arguments</h6>
+<h6 id="_callback_arguments_45">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7464,7 +7965,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_123">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_133">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSerialNumber</span>(serialNumber)
@@ -7479,13 +7980,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusCSKIODDInterpreterAvailable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusCSKIODDInterpreterAvailable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_125">Short description</h6>
+<h6 id="_short_description_128">Short description</h6>
 <div class="paragraph">
 <p>Event to show if there is available CSK IODD interpreter in the project.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_43">Callback arguments</h6>
+<h6 id="_callback_arguments_46">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7512,7 +8013,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_124">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_134">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusCSKIODDInterpreterAvailable</span>(isAvailable)
@@ -7527,13 +8028,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusCSKStyle"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusCSKStyle</span></h5>
 <div class="sect5">
-<h6 id="_short_description_126">Short description</h6>
+<h6 id="_short_description_129">Short description</h6>
 <div class="paragraph">
 <p>Notify UI style to use for CSK modules.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_44">Callback arguments</h6>
+<h6 id="_callback_arguments_47">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7560,7 +8061,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_125">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_135">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusCSKStyle</span>(theme)
@@ -7575,13 +8076,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusFlowConfigPriority"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusFlowConfigPriority</span></h5>
 <div class="sect5">
-<h6 id="_short_description_127">Short description</h6>
+<h6 id="_short_description_130">Short description</h6>
 <div class="paragraph">
 <p>Notify if FlowConfig should have priority for FlowConfig relevant configurations.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_45">Callback arguments</h6>
+<h6 id="_callback_arguments_48">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7608,7 +8109,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_126">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_136">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusFlowConfigPriority</span>(status)
@@ -7623,13 +8124,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusInstanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusInstanceActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_128">Short description</h6>
+<h6 id="_short_description_131">Short description</h6>
 <div class="paragraph">
 <p>Notify if instance is activated.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_46">Callback arguments</h6>
+<h6 id="_callback_arguments_49">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7656,7 +8157,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_127">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_137">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusInstanceActive</span>(status)
@@ -7671,13 +8172,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDMatchFound"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDMatchFound</span></h5>
 <div class="sect5">
-<h6 id="_short_description_129">Short description</h6>
+<h6 id="_short_description_132">Short description</h6>
 <div class="paragraph">
 <p>Event to notify if there is a matching IODD file found by IODD interpreter module.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_47">Callback arguments</h6>
+<h6 id="_callback_arguments_50">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7704,7 +8205,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_128">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_138">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusIODDMatchFound</span>(isFound)
@@ -7719,153 +8220,9 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDReadMessageSelected"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDReadMessageSelected</span></h5>
 <div class="sect5">
-<h6 id="_short_description_130">Short description</h6>
-<div class="paragraph">
-<p>Event to inform if the read message is selected in UI. Used to show settings in UI.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_48">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">isSelected</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">True if selected.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_129">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusIODDReadMessageSelected</span>(isSelected)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusIODDReadMessageSelected</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusIODDReadMessageSelected</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDWriteMessageSelected"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDWriteMessageSelected</span></h5>
-<div class="sect5">
-<h6 id="_short_description_131">Short description</h6>
-<div class="paragraph">
-<p>Event to inform if the write message is selected in UI. Used to show settings in UI.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_49">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">isSelected</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">True if selected.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_130">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusIODDWriteMessageSelected</span>(isSelected)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusIODDWriteMessageSelected</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusIODDWriteMessageSelected</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusLoadParameterOnReboot</span></h5>
-<div class="sect5">
-<h6 id="_short_description_132">Short description</h6>
-<div class="paragraph">
-<p>Notify status if parameters should be loaded on app-/device- boot up.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_50">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_131">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusLoadParameterOnReboot</span>(status)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusLoadParameterOnReboot</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusModuleIsActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusModuleIsActive</span></h5>
-<div class="sect5">
 <h6 id="_short_description_133">Short description</h6>
 <div class="paragraph">
-<p>Notify if module can be used on device.</p>
+<p>Event to inform if the read message is selected in UI. Used to show settings in UI.</p>
 </div>
 </div>
 <div class="sect5">
@@ -7887,6 +8244,102 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">isSelected</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">True if selected.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_139">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusIODDReadMessageSelected</span>(isSelected)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusIODDReadMessageSelected</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusIODDReadMessageSelected</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDWriteMessageSelected"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDWriteMessageSelected</span></h5>
+<div class="sect5">
+<h6 id="_short_description_134">Short description</h6>
+<div class="paragraph">
+<p>Event to inform if the write message is selected in UI. Used to show settings in UI.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_52">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">isSelected</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">True if selected.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_140">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusIODDWriteMessageSelected</span>(isSelected)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusIODDWriteMessageSelected</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusIODDWriteMessageSelected</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusLoadParameterOnReboot</span></h5>
+<div class="sect5">
+<h6 id="_short_description_135">Short description</h6>
+<div class="paragraph">
+<p>Notify status if parameters should be loaded on app-/device- boot up.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_53">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
@@ -7896,7 +8349,55 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_132">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_141">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusLoadParameterOnReboot</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusLoadParameterOnReboot</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusModuleIsActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusModuleIsActive</span></h5>
+<div class="sect5">
+<h6 id="_short_description_136">Short description</h6>
+<div class="paragraph">
+<p>Notify if module can be used on device.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_54">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_142">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusModuleIsActive</span>(status)
@@ -7911,13 +8412,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusModuleVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusModuleVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_134">Short description</h6>
+<h6 id="_short_description_137">Short description</h6>
 <div class="paragraph">
 <p>Notify version of module.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_52">Callback arguments</h6>
+<h6 id="_callback_arguments_55">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7944,7 +8445,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_133">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_143">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusModuleVersion</span>(version)
@@ -7959,13 +8460,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusNewDeviceFound"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusNewDeviceFound</span></h5>
 <div class="sect5">
-<h6 id="_short_description_135">Short description</h6>
+<h6 id="_short_description_138">Short description</h6>
 <div class="paragraph">
 <p>Event to notify if there is a new device discovered on selected port. Used to show settings in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_53">Callback arguments</h6>
+<h6 id="_callback_arguments_56">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -7992,7 +8493,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_134">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_144">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusNewDeviceFound</span>(state)
@@ -8007,13 +8508,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusProcessDataVariable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusProcessDataVariable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_136">Short description</h6>
+<h6 id="_short_description_139">Short description</h6>
 <div class="paragraph">
 <p>Event to show additional settings if process data of the IO-Link device has a variable structure.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_54">Callback arguments</h6>
+<h6 id="_callback_arguments_57">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8040,7 +8541,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_135">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_145">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusProcessDataVariable</span>(state)
@@ -8055,13 +8556,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTestCommandState"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTestCommandState</span></h5>
 <div class="sect5">
-<h6 id="_short_description_137">Short description</h6>
+<h6 id="_short_description_140">Short description</h6>
 <div class="paragraph">
 <p>Event to show latest status of reading or writing raw byte arrays from/to IO-Link device for testing purpuses.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_55">Callback arguments</h6>
+<h6 id="_callback_arguments_58">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8088,7 +8589,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_136">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_146">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewTestCommandState</span>(state)
@@ -8103,13 +8604,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTestWriteIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTestWriteIODDMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_138">Short description</h6>
+<h6 id="_short_description_141">Short description</h6>
 <div class="paragraph">
 <p>Event to show the edited JSON payload of write message be sent to IO-Link device for testing purposes.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_56">Callback arguments</h6>
+<h6 id="_callback_arguments_59">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8136,7 +8637,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_137">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_147">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewTestWriteIODDMessage</span>(testWriteIODDMessage)
@@ -8151,13 +8652,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTriggerType"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTriggerType</span></h5>
 <div class="sect5">
-<h6 id="_short_description_139">Short description</h6>
+<h6 id="_short_description_142">Short description</h6>
 <div class="paragraph">
 <p>Event to show the selected trigger type of selected read message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_57">Callback arguments</h6>
+<h6 id="_callback_arguments_60">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8184,7 +8685,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_138">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_148">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewTriggerType</span>(triggerType)
@@ -8199,13 +8700,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTriggerValue"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTriggerValue</span></h5>
 <div class="sect5">
-<h6 id="_short_description_140">Short description</h6>
+<h6 id="_short_description_143">Short description</h6>
 <div class="paragraph">
 <p>Event to show the selected trigger value of selected read message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_58">Callback arguments</h6>
+<h6 id="_callback_arguments_61">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8232,7 +8733,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_139">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_149">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewTriggerValue</span>(triggerValue)
@@ -8247,14 +8748,14 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewValueToForwardNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewValueToForwardNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_141">Short description</h6>
+<h6 id="_short_description_144">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to forward data from instance thread to Controller part of module, e.g. to forward values to UI.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewValueToForward1").<br></p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_59">Callback arguments</h6>
+<h6 id="_callback_arguments_62">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8287,7 +8788,7 @@ NUM will be replaced by the number of instance (e.g. "OnNewValueToForward1").<br
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_140">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_150">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewValueToForwardNUM</span>(eventname, value)
@@ -8302,14 +8803,14 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewValueUpdateNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewValueUpdateNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_142">Short description</h6>
+<h6 id="_short_description_145">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to sync paramters between instance threads and Controller part of module.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewResult1").<br></p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_60">Callback arguments</h6>
+<h6 id="_callback_arguments_63">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8354,7 +8855,7 @@ NUM will be replaced by the number of instance (e.g. "OnNewResult1").<br></p>
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_141">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_151">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewValueUpdateNUM</span>(instance, parameter, value, selectedObject)
@@ -8369,13 +8870,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_143">Short description</h6>
+<h6 id="_short_description_146">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor ID of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_61">Callback arguments</h6>
+<h6 id="_callback_arguments_64">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8402,7 +8903,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_142">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_152">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewVendorId</span>(vendorId)
@@ -8417,13 +8918,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_144">Short description</h6>
+<h6 id="_short_description_147">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor name of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_62">Callback arguments</h6>
+<h6 id="_callback_arguments_65">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8450,7 +8951,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_143">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_153">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewVendorName</span>(vendorName)
@@ -8465,13 +8966,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_145">Short description</h6>
+<h6 id="_short_description_148">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor text of connected IO-Link device.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_63">Callback arguments</h6>
+<h6 id="_callback_arguments_66">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8498,7 +8999,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_144">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_154">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewVendorText</span>(vendorText)
@@ -8513,13 +9014,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteDataMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_146">Short description</h6>
+<h6 id="_short_description_149">Short description</h6>
 <div class="paragraph">
 <p>Event to show the latest payload of write message sent to IO-Link device after refresh button has been pressed.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_64">Callback arguments</h6>
+<h6 id="_callback_arguments_67">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8546,7 +9047,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_145">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_155">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewWriteDataMessage</span>(message)
@@ -8561,13 +9062,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteDataSuccess"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteDataSuccess</span></h5>
 <div class="sect5">
-<h6 id="_short_description_147">Short description</h6>
+<h6 id="_short_description_150">Short description</h6>
 <div class="paragraph">
 <p>Event to show the latest success of writing message to IO-Link device after refresh button has been pressed.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_65">Callback arguments</h6>
+<h6 id="_callback_arguments_68">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8594,7 +9095,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_146">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_156">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewWriteDataSuccess</span>(success)
@@ -8609,13 +9110,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteJSONTemplate</span></h5>
 <div class="sect5">
-<h6 id="_short_description_148">Short description</h6>
+<h6 id="_short_description_151">Short description</h6>
 <div class="paragraph">
 <p>Event to show JSON template of configured write message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_66">Callback arguments</h6>
+<h6 id="_callback_arguments_69">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8642,7 +9143,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_147">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_157">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewWriteJSONTemplate</span>(writeJSONTemplate)
@@ -8657,13 +9158,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteMessageFunctionName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteMessageFunctionName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_149">Short description</h6>
+<h6 id="_short_description_152">Short description</h6>
 <div class="paragraph">
 <p>Event to notify the name of the write data function that can be used externally.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_67">Callback arguments</h6>
+<h6 id="_callback_arguments_70">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8690,7 +9191,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_148">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_158">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewWriteMessageFunctionName</span>(functionName)
@@ -8705,13 +9206,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteParametersTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteParametersTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_150">Short description</h6>
+<h6 id="_short_description_153">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewWriteParametersTableContent event to fill the parameter table of the write message.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_68">Callback arguments</h6>
+<h6 id="_callback_arguments_71">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -8738,7 +9239,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_149">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_159">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewWriteParametersTableContentCSKIODDInterpreter</span>(tableContent)
@@ -8753,153 +9254,9 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnPersistentDataModuleAvailable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnPersistentDataModuleAvailable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_151">Short description</h6>
-<div class="paragraph">
-<p>Notify status if features of CSK_PersistentData module are available.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_69">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_150">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnPersistentDataModuleAvailable</span>(status)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnPersistentDataModuleAvailable</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnPersistentDataModuleAvailable</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelAdminActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelAdminActive</span></h5>
-<div class="sect5">
-<h6 id="_short_description_152">Short description</h6>
-<div class="paragraph">
-<p>Status of Admin userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_70">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_151">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelAdminActive</span>(status)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelMaintenanceActive</span></h5>
-<div class="sect5">
-<h6 id="_short_description_153">Short description</h6>
-<div class="paragraph">
-<p>Status of Maintenance userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_71">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_152">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelMaintenanceActive</span>(status)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelOperatorActive</span></h5>
-<div class="sect5">
 <h6 id="_short_description_154">Short description</h6>
 <div class="paragraph">
-<p>Status of Operator userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+<p>Notify status if features of CSK_PersistentData module are available.</p>
 </div>
 </div>
 <div class="sect5">
@@ -8930,24 +9287,24 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_153">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_160">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelOperatorActive</span>(status)
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnPersistentDataModuleAvailable</span>(status)
   <span class="comment">-- Do something</span>
 <span class="keyword">end</span>
 
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnPersistentDataModuleAvailable</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnPersistentDataModuleAvailable</span><span class="delimiter">&quot;</span></span>)</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelServiceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelServiceActive</span></h5>
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelAdminActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelAdminActive</span></h5>
 <div class="sect5">
 <h6 id="_short_description_155">Short description</h6>
 <div class="paragraph">
-<p>Status of Service userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+<p>Status of Admin userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
 </div>
 <div class="sect5">
@@ -8978,7 +9335,151 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_154">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_161">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelAdminActive</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelMaintenanceActive</span></h5>
+<div class="sect5">
+<h6 id="_short_description_156">Short description</h6>
+<div class="paragraph">
+<p>Status of Maintenance userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_74">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_162">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelMaintenanceActive</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelOperatorActive</span></h5>
+<div class="sect5">
+<h6 id="_short_description_157">Short description</h6>
+<div class="paragraph">
+<p>Status of Operator userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_75">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_163">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelOperatorActive</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.OnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelServiceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelServiceActive</span></h5>
+<div class="sect5">
+<h6 id="_short_description_158">Short description</h6>
+<div class="paragraph">
+<p>Status of Service userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_76">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_164">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelServiceActive</span>(status)
@@ -8990,12 +9491,84 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 </div>
 </div>
+<div class="sect4">
+<h5 id="API:Event:CSK_MultiIOLinkSMI.readMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">readMessagePortMessageName</span></h5>
+<div class="sect5">
+<h6 id="_short_description_159">Short description</h6>
+<div class="paragraph">
+<p>Event that can be used to get the message with data received from IOLink device. Port - sensor port the device is connected to (S1,S2 &#8230;&#8203;). MessageName - the configured name of the message.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_77">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Success of reading data.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">queueSize</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Size of the queue calls in the thread responsible for communication with this IOLink device. If the queue builds up, this can lead to memory overflow. That&#8217;s why the queue is recet to 0 in case there are more than 10 calls.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">time</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Time in milliseconds spent for getting and parsing the data.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">data</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object containing the interpreted data.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">detailedErrorMessage</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Error message, if any.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_165">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handlereadMessagePortMessageName</span>(success, queueSize, time, data, detailedErrorMessage)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_MultiIOLinkSMI.readMessagePortMessageName</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handlereadMessagePortMessageName</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect2">
 <h3 id="API:Crown:MultiIOLinkSMI_FC"><span class="api-crown">MultiIOLinkSMI_FC</span></h3>
 <div class="sect3">
-<h4 id="_short_description_156">Short description</h4>
+<h4 id="_short_description_160">Short description</h4>
 <div class="paragraph">
 <p>Crown to provide CSK_FlowConfig relevant features.</p>
 </div>
@@ -9008,7 +9581,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect2">
 <h3 id="API:Crown:MultiIOLinkSMI_FC.OnNewData"><span class="api-crown">MultiIOLinkSMI_FC.OnNewData</span></h3>
 <div class="sect3">
-<h4 id="_short_description_157">Short description</h4>
+<h4 id="_short_description_161">Short description</h4>
 <div class="admonitionblock important">
 <table>
 <tr>
@@ -9044,13 +9617,13 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Function:MultiIOLinkSMI_FC.OnNewData.create"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-function">create()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_158">Short description</h6>
+<h6 id="_short_description_162">Short description</h6>
 <div class="paragraph">
 <p>Internally used CSK_FlowConfig create function.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_55">Parameters</h6>
+<h6 id="_parameters_56">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -9083,7 +9656,7 @@ Provide IOLink data via event.
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_33">Return values</h6>
+<h6 id="_return_values_38">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -9110,7 +9683,7 @@ Provide IOLink data via event.
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_155">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_166">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">handle = MultiIOLinkSMI_FC.OnNewData.create(Instance, ReadMessageName)</code></pre>
@@ -9121,13 +9694,13 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Function:MultiIOLinkSMI_FC.OnNewData.register"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-function">register()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_159">Short description</h6>
+<h6 id="_short_description_163">Short description</h6>
 <div class="paragraph">
 <p>Internally used CSK_FlowConfig register function.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_56">Parameters</h6>
+<h6 id="_parameters_57">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -9166,7 +9739,7 @@ Provide IOLink data via event.
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_34">Return values</h6>
+<h6 id="_return_values_39">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -9193,7 +9766,7 @@ Provide IOLink data via event.
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_156">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_167">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua">success = MultiIOLinkSMI_FC.OnNewData.register(handle, eventname, callback)</code></pre>
@@ -9207,7 +9780,7 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Event:MultiIOLinkSMI_FC.OnNewData.OnNewData"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-event">OnNewData</span></h5>
 <div class="sect5">
-<h6 id="_short_description_160">Short description</h6>
+<h6 id="_short_description_164">Short description</h6>
 <div class="admonitionblock important">
 <table>
 <tr>
@@ -9223,7 +9796,7 @@ Provide IOLink data via event.
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_74">Callback arguments</h6>
+<h6 id="_callback_arguments_78">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -9242,7 +9815,7 @@ Provide IOLink data via event.
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">handle</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HANDLE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BINARY</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Handle to internally used FlowConfig instance.</p></td>
 </tr>
@@ -9262,7 +9835,7 @@ Parameter:
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_157">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_168">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewData</span>(handle, OnNewData)
@@ -9282,7 +9855,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 2.0.0<br>
-Last updated 2024-08-14 16:17:53 +0200
+Last updated 2024-10-21 09:54:47 +0200
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_MultiIOLinkSMI.html
+++ b/docu/CSK_Module_MultiIOLinkSMI.html
@@ -814,13 +814,13 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </li>
 <li><a href="#API:Crown:MultiIOLinkSMI_FC"><span class="api-crown">MultiIOLinkSMI_FC</span></a>
 <ul class="sectlevel3">
-<li><a href="#_short_description_160">Short description</a></li>
+<li><a href="#_short_description_167">Short description</a></li>
 <li><a href="#_overview_3">Overview</a></li>
 </ul>
 </li>
 <li><a href="#API:Crown:MultiIOLinkSMI_FC.OnNewData"><span class="api-crown">MultiIOLinkSMI_FC.OnNewData</span></a>
 <ul class="sectlevel3">
-<li><a href="#_short_description_161">Short description</a></li>
+<li><a href="#_short_description_168">Short description</a></li>
 <li><a href="#_overview_4">Overview</a></li>
 <li><a href="#_functions_2">Functions</a>
 <ul class="sectlevel4">
@@ -1626,6 +1626,13 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.copyReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyReadDataMessage()</span></h5>
 <div class="sect5">
+<h6 id="_short_description_8">Short description</h6>
+<div class="paragraph">
+<p>Function to copy the selected read data message. It can be pasted in another instance (IOLink device) if the device is same. Pasting is done via
+pasteReadDataMessage.</p>
+</div>
+</div>
+<div class="sect5">
 <h6 id="_sample_auto_generated_6">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
@@ -1636,6 +1643,13 @@ The following functions can be used for reading or writing data by selected inst
 </div>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.copyWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">copyWriteDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_9">Short description</h6>
+<div class="paragraph">
+<p>Function to copy the selected write data message. It can be pasted in another instance (IOLink device) if the device is same. Pasting is done via
+pasteWriteDataMessage.</p>
+</div>
+</div>
 <div class="sect5">
 <h6 id="_sample_auto_generated_7">Sample (auto-generated)</h6>
 <div class="listingblock">
@@ -1648,7 +1662,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.createIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">createIODDReadMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_8">Short description</h6>
+<h6 id="_short_description_10">Short description</h6>
 <div class="paragraph">
 <p>Create a new data set to read from device with the help of IODD interpreter.</p>
 </div>
@@ -1665,7 +1679,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.createIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">createIODDWriteMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_9">Short description</h6>
+<h6 id="_short_description_11">Short description</h6>
 <div class="paragraph">
 <p>Create a new data set to write to device with the help of IODD interpreter.</p>
 </div>
@@ -1682,7 +1696,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.deleteIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">deleteIODDReadMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_10">Short description</h6>
+<h6 id="_short_description_12">Short description</h6>
 <div class="paragraph">
 <p>Delete created data set.</p>
 </div>
@@ -1699,7 +1713,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.deleteIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">deleteIODDWriteMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_11">Short description</h6>
+<h6 id="_short_description_13">Short description</h6>
 <div class="paragraph">
 <p>Delete created data set.</p>
 </div>
@@ -1716,8 +1730,10 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getDeviceConfig"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceConfig()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_12">Short description</h6>
-
+<h6 id="_short_description_14">Short description</h6>
+<div class="paragraph">
+<p>Function to get the device configuration that can be use to copy it and apply for another device if DeviceId and VendorId are matched.</p>
+</div>
 </div>
 <div class="sect5">
 <h6 id="_return_values">Return values</h6>
@@ -1741,7 +1757,7 @@ The following functions can be used for reading or writing data by selected inst
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonCopiedDeviceConfig</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with device configuration</p></td>
 </tr>
 </tbody>
 </table>
@@ -1758,7 +1774,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getDeviceIdentification"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getDeviceIdentification()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_13">Short description</h6>
+<h6 id="_short_description_15">Short description</h6>
 <div class="paragraph">
 <p>Get identification of a device connected to a specified port. The identification contains the following parameters:<br>
 *statusInfo - status of the IO-Link port<br>
@@ -1838,7 +1854,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getInstanceParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstanceParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_14">Short description</h6>
+<h6 id="_short_description_16">Short description</h6>
 <div class="paragraph">
 <p>Get all parameters of the instance</p>
 </div>
@@ -1909,8 +1925,10 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getInstancePortMap"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancePortMap()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_15">Short description</h6>
-
+<h6 id="_short_description_17">Short description</h6>
+<div class="paragraph">
+<p>Function to get a map of what ports are controlled by instances.</p>
+</div>
 </div>
 <div class="sect5">
 <h6 id="_return_values_4">Return values</h6>
@@ -1934,7 +1952,7 @@ The following functions can be used for reading or writing data by selected inst
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonInstancePortMap</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with the map.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1951,7 +1969,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getInstancesAmount"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getInstancesAmount()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_16">Short description</h6>
+<h6 id="_short_description_18">Short description</h6>
 <div class="paragraph">
 <p>Get the amount of created instances of this module.</p>
 </div>
@@ -1995,7 +2013,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getIODDReadMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDReadMessageJSONTemplate()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_17">Short description</h6>
+<h6 id="_short_description_19">Short description</h6>
 <div class="paragraph">
 <p>Function to get the JSON template of the message that will be read from IO-Link device.</p>
 </div>
@@ -2066,7 +2084,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getIODDWriteMessageJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getIODDWriteMessageJSONTemplate()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_18">Short description</h6>
+<h6 id="_short_description_20">Short description</h6>
 <div class="paragraph">
 <p>Function to get the JSON template of the message that is expected to be written to IO-Link device.</p>
 </div>
@@ -2137,7 +2155,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_19">Short description</h6>
+<h6 id="_short_description_21">Short description</h6>
 <div class="paragraph">
 <p>Function to get all parameters of the client in JSON format.</p>
 </div>
@@ -2208,7 +2226,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getPort()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_20">Short description</h6>
+<h6 id="_short_description_22">Short description</h6>
 <div class="paragraph">
 <p>Function to get port of currently selected instance.</p>
 </div>
@@ -2252,7 +2270,7 @@ The following functions can be used for reading or writing data by selected inst
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getReadDataResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getReadDataResultNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_21">Short description</h6>
+<h6 id="_short_description_23">Short description</h6>
 <div class="paragraph">
 <p>Get the latest result of readinig message.<br>
 NUM will be replaced by the number of instance (e.g. "getReadDataResult1").<br></p>
@@ -2330,7 +2348,7 @@ NUM will be replaced by the number of instance (e.g. "getReadDataResult1").<br><
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getStatusModuleActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getStatusModuleActive()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_22">Short description</h6>
+<h6 id="_short_description_24">Short description</h6>
 <div class="paragraph">
 <p>Function to get status if module is active.</p>
 </div>
@@ -2374,7 +2392,7 @@ NUM will be replaced by the number of instance (e.g. "getReadDataResult1").<br><
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.getWriteDataResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">getWriteDataResultNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_23">Short description</h6>
+<h6 id="_short_description_25">Short description</h6>
 <div class="paragraph">
 <p>Get the latest result of writng message.<br>
 NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
@@ -2452,7 +2470,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.handleOnNewPortEvent"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">handleOnNewPortEvent()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_24">Short description</h6>
+<h6 id="_short_description_26">Short description</h6>
 <div class="paragraph">
 <p>Internally used function triggered when the new event occurs in IO-Link port.</p>
 </div>
@@ -2510,7 +2528,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.loadParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">loadParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_25">Short description</h6>
+<h6 id="_short_description_27">Short description</h6>
 <div class="paragraph">
 <p>Load parameters for this module from the CSK_PersistentData module if possible and use them.</p>
 </div>
@@ -2554,7 +2572,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.makeDefaultInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">makeDefaultInstance()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_26">Short description</h6>
+<h6 id="_short_description_28">Short description</h6>
 <div class="paragraph">
 <p>Set all instance parameters to default values.</p>
 </div>
@@ -2571,7 +2589,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.pageCalled"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pageCalled()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_27">Short description</h6>
+<h6 id="_short_description_29">Short description</h6>
 <div class="paragraph">
 <p>Function to register "OnResume" of the module UI (only as helper function).</p>
 </div>
@@ -2615,6 +2633,12 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.pasteReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteReadDataMessage()</span></h5>
 <div class="sect5">
+<h6 id="_short_description_30">Short description</h6>
+<div class="paragraph">
+<p>Function to paste the copied read data message configuration. See copyReadDataMessage</p>
+</div>
+</div>
+<div class="sect5">
 <h6 id="_return_values_15">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -2636,19 +2660,19 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">processDataTableContent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with selected process data information.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">parameterTableContent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with selected parameters information.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">New JSON template of the read message.</p></td>
 </tr>
 </tbody>
 </table>
@@ -2664,6 +2688,12 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 </div>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.pasteWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">pasteWriteDataMessage()</span></h5>
+<div class="sect5">
+<h6 id="_short_description_31">Short description</h6>
+<div class="paragraph">
+<p>Function to paste the copied write data message configuration. See copyWriteDataMessage</p>
+</div>
+</div>
 <div class="sect5">
 <h6 id="_return_values_16">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
@@ -2686,19 +2716,19 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">processDataTableContent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with selected process data information.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">parameterTableContent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object with selected parameters information.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">New JSON template of the write message.</p></td>
 </tr>
 </tbody>
 </table>
@@ -2715,7 +2745,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.processDataInRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataInRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_28">Short description</h6>
+<h6 id="_short_description_32">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.processDataInRowSelected function when row in process data in of read message table is selected.</p>
 </div>
@@ -2759,7 +2789,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.processDataOutRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">processDataOutRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_29">Short description</h6>
+<h6 id="_short_description_33">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.processDataOutRowSelected function when row in process data out of write message table is selected.</p>
 </div>
@@ -2803,7 +2833,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_30">Short description</h6>
+<h6 id="_short_description_34">Short description</h6>
 <div class="paragraph">
 <p>Read configured message from IO-Link sensor.</p>
 </div>
@@ -2880,7 +2910,7 @@ NUM will be replaced by the number of instance (e.g. "getWriteDataResult1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessageNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessageNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_31">Short description</h6>
+<h6 id="_short_description_35">Short description</h6>
 <div class="paragraph">
 <p>Read preconfigured message.<br>
 NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
@@ -2958,7 +2988,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readIODDMessageUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readIODDMessageUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_32">Short description</h6>
+<h6 id="_short_description_36">Short description</h6>
 <div class="paragraph">
 <p>Read configured message from IO-Link sensor from UI.</p>
 </div>
@@ -2975,7 +3005,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_33">Short description</h6>
+<h6 id="_short_description_37">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
@@ -3058,7 +3088,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_34">Short description</h6>
+<h6 id="_short_description_38">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor as a raw byte array. Might be useful for testing.  If reading failed, returns nil.</p>
 </div>
@@ -3135,7 +3165,7 @@ NUM will be replaced by the number of instance (e.g. "readIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_35">Short description</h6>
+<h6 id="_short_description_39">Short description</h6>
 <div class="paragraph">
 <p>Read paramerter and return it as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -3216,7 +3246,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_36">Short description</h6>
+<h6 id="_short_description_40">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor as a raw byte array to show it in UI.</p>
 </div>
@@ -3233,7 +3263,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterByteArray_1")
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_37">Short description</h6>
+<h6 id="_short_description_41">Short description</h6>
 <div class="paragraph">
 <p>Read parameter with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table.<br>
 NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br></p>
@@ -3317,7 +3347,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readParameterRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readParameterRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_38">Short description</h6>
+<h6 id="_short_description_42">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.readParameterRowSelected function when row in read parameters table of read message is selected.</p>
 </div>
@@ -3361,7 +3391,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessData"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessData()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_39">Short description</h6>
+<h6 id="_short_description_43">Short description</h6>
 <div class="paragraph">
 <p>Read parameter of IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
@@ -3411,7 +3441,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_40">Short description</h6>
+<h6 id="_short_description_44">Short description</h6>
 <div class="paragraph">
 <p>Read process data of IO-Link sensor as a raw byte array. Might be useful for testing. If reading failed, returns nil.</p>
 </div>
@@ -3455,7 +3485,7 @@ NUM will be replaced by the number of instance (e.g. "readParameterIODD_1").<br>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_41">Short description</h6>
+<h6 id="_short_description_45">Short description</h6>
 <div class="paragraph">
 <p>Read process data and return it as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -3503,7 +3533,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_42">Short description</h6>
+<h6 id="_short_description_46">Short description</h6>
 <div class="paragraph">
 <p>Read process data of IO-Link sensor as a raw byte array to show it in UI.</p>
 </div>
@@ -3520,7 +3550,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataByteArray_1
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.readProcessDataIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">readProcessDataIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_43">Short description</h6>
+<h6 id="_short_description_47">Short description</h6>
 <div class="paragraph">
 <p>Read process data with provided info from IODD interpreter (as JSON table) and convert it to a meaningful JSON table.<br>
 NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</p>
@@ -3592,7 +3622,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.refreshReadDataResult"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">refreshReadDataResult()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_44">Short description</h6>
+<h6 id="_short_description_48">Short description</h6>
 <div class="paragraph">
 <p>Function to show the latest read result of the selected message in UI.</p>
 </div>
@@ -3609,7 +3639,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.refreshWriteDataResult"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">refreshWriteDataResult()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_45">Short description</h6>
+<h6 id="_short_description_49">Short description</h6>
 <div class="paragraph">
 <p>Function to show the latest write result of the selected message in UI.</p>
 </div>
@@ -3626,7 +3656,7 @@ NUM will be replaced by the number of instance (e.g. "readProcessDataIODD_1").</
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.resetInstances"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">resetInstances()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_46">Short description</h6>
+<h6 id="_short_description_50">Short description</h6>
 <div class="paragraph">
 <p>Function to reset instances to one single instance.<br>
 IMPORTANT: As instances start their own threads, the module needs to be restarted if new instances are needed&#8230;&#8203; (see AppEngine docu for "Script.startScript").</p>
@@ -3644,7 +3674,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.resetModule"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">resetModule()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_47">Short description</h6>
+<h6 id="_short_description_51">Short description</h6>
 <div class="paragraph">
 <p>Function to reset main configuration of module.</p>
 </div>
@@ -3661,7 +3691,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.sendParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">sendParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_48">Short description</h6>
+<h6 id="_short_description_52">Short description</h6>
 <div class="paragraph">
 <p>Send parameters to CSK_PersistentData module if possible to save them.</p>
 </div>
@@ -3705,7 +3735,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setFlowConfigPriority"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setFlowConfigPriority()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_49">Short description</h6>
+<h6 id="_short_description_53">Short description</h6>
 <div class="paragraph">
 <p>Function to configure if FlowConfig should have priority for FlowConfig relevant configuration.</p>
 </div>
@@ -3749,7 +3779,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setIODDReadMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setIODDReadMessageName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_50">Short description</h6>
+<h6 id="_short_description_54">Short description</h6>
 <div class="paragraph">
 <p>Set title of the message to read from IO-Link device.</p>
 </div>
@@ -3793,7 +3823,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setIODDWriteMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setIODDWriteMessageName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_51">Short description</h6>
+<h6 id="_short_description_55">Short description</h6>
 <div class="paragraph">
 <p>Set title of the message to write to IO-Link device.</p>
 </div>
@@ -3837,7 +3867,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setLoadOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setLoadOnReboot()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_52">Short description</h6>
+<h6 id="_short_description_56">Short description</h6>
 <div class="paragraph">
 <p>Configure if this module should load its saved parameters at app/ device boot up.</p>
 </div>
@@ -3881,7 +3911,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setParameterByteArrayToWrite"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setParameterByteArrayToWrite()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_53">Short description</h6>
+<h6 id="_short_description_57">Short description</h6>
 <div class="paragraph">
 <p>Set byte array to write to the parameter of the device for testing purposes in UI.</p>
 </div>
@@ -3925,7 +3955,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setParameterName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setParameterName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_54">Short description</h6>
+<h6 id="_short_description_58">Short description</h6>
 <div class="paragraph">
 <p>Function to set the name of the parameters if saved/loaded via the CSK_PersistentData module.</p>
 </div>
@@ -3969,7 +3999,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setPort()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_55">Short description</h6>
+<h6 id="_short_description_59">Short description</h6>
 <div class="paragraph">
 <p>Set an IO-Link port for selected instance.</p>
 </div>
@@ -4013,7 +4043,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setProcessDataByteArrayToWrite"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setProcessDataByteArrayToWrite()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_56">Short description</h6>
+<h6 id="_short_description_60">Short description</h6>
 <div class="paragraph">
 <p>Set byte array to write to the process data of the device for testing purposes in UI.</p>
 </div>
@@ -4057,7 +4087,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setProcessDataCondition()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_57">Short description</h6>
+<h6 id="_short_description_61">Short description</h6>
 <div class="paragraph">
 <p>Set process data structure varient if the structure is variable. The respective value will be sent to the parameter responsible for the structure.</p>
 </div>
@@ -4101,7 +4131,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedInstance()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_58">Short description</h6>
+<h6 id="_short_description_62">Short description</h6>
 <div class="paragraph">
 <p>Select one of the multiple instances.</p>
 </div>
@@ -4145,7 +4175,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedIODDReadMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_59">Short description</h6>
+<h6 id="_short_description_63">Short description</h6>
 <div class="paragraph">
 <p>Select a read message to edit.</p>
 </div>
@@ -4189,7 +4219,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedIODDWriteMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_60">Short description</h6>
+<h6 id="_short_description_64">Short description</h6>
 <div class="paragraph">
 <p>Select a write message to edit.</p>
 </div>
@@ -4233,7 +4263,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setSelectedTab"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setSelectedTab()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_61">Short description</h6>
+<h6 id="_short_description_65">Short description</h6>
 <div class="paragraph">
 <p>Select tab in UI.</p>
 </div>
@@ -4277,7 +4307,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestReadParameterIndex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestReadParameterIndex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_62">Short description</h6>
+<h6 id="_short_description_66">Short description</h6>
 <div class="paragraph">
 <p>Set index of the parameter to read as byte array in UI.</p>
 </div>
@@ -4321,7 +4351,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestReadParameterSubindex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestReadParameterSubindex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_63">Short description</h6>
+<h6 id="_short_description_67">Short description</h6>
 <div class="paragraph">
 <p>Set subindex of the parameter to read as byte array in UI.</p>
 </div>
@@ -4365,7 +4395,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_64">Short description</h6>
+<h6 id="_short_description_68">Short description</h6>
 <div class="paragraph">
 <p>Set JSON content of message to write to device. The content must have the same format as JSON template of the selected message (template is generated based on selected paramters/process data).</p>
 </div>
@@ -4409,7 +4439,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteParameterIndex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteParameterIndex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_65">Short description</h6>
+<h6 id="_short_description_69">Short description</h6>
 <div class="paragraph">
 <p>Set index of the parameter to write as byte array in UI.</p>
 </div>
@@ -4453,7 +4483,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTestWriteParameterSubindex"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTestWriteParameterSubindex()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_66">Short description</h6>
+<h6 id="_short_description_70">Short description</h6>
 <div class="paragraph">
 <p>Set subindex of the parameter to write as byte array in UI.</p>
 </div>
@@ -4497,7 +4527,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTriggerType"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTriggerType()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_67">Short description</h6>
+<h6 id="_short_description_71">Short description</h6>
 <div class="paragraph">
 <p>Set condition of when to read the selected read message. Possible options:<br>
 *Periodic - the message is periodically requested from the IO-Link device. The period can be set by setTriggerValue function.<br>
@@ -4543,7 +4573,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.setTriggerValue"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">setTriggerValue()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_68">Short description</h6>
+<h6 id="_short_description_72">Short description</h6>
 <div class="paragraph">
 <p>Set value depending on the selected trigger type of the selected read message.<br>
 *if type is 'Periodic' - period in [ms].<br>
@@ -4589,7 +4619,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.updateInstanceParameters"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">updateInstanceParameters()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_69">Short description</h6>
+<h6 id="_short_description_73">Short description</h6>
 <div class="paragraph">
 <p>Update all parameters of specified instance. Following is sample structure of JSON table with parameters:<br></p>
 </div>
@@ -4681,7 +4711,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.uploadFinishedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">uploadFinishedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_70">Short description</h6>
+<h6 id="_short_description_74">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.uploadFinished function when IODD file upload is finished.</p>
 </div>
@@ -4725,7 +4755,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessage()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_71">Short description</h6>
+<h6 id="_short_description_75">Short description</h6>
 <div class="paragraph">
 <p>Write configured message to IO-Link sensor.</p>
 </div>
@@ -4802,7 +4832,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessageFromUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageFromUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_72">Short description</h6>
+<h6 id="_short_description_76">Short description</h6>
 <div class="paragraph">
 <p>Write configured message to IO-Link sensor from UI.</p>
 </div>
@@ -4819,7 +4849,7 @@ IMPORTANT: As instances start their own threads, the module needs to be restarte
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeIODDMessageNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeIODDMessageNUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_73">Short description</h6>
+<h6 id="_short_description_77">Short description</h6>
 <div class="paragraph">
 <p>Write preconfigured message.<br>
 NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
@@ -4903,7 +4933,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeMessagePortMessageName()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_74">Short description</h6>
+<h6 id="_short_description_78">Short description</h6>
 <div class="paragraph">
 <p>Function to write the message with to IOLink device. The data must a JSON object that has the same structure as the configured message. Port - sensor port the device is connected to (S1,S2 &#8230;&#8203;). MessageName - the configured name of the message.</p>
 </div>
@@ -4992,7 +5022,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_75">Short description</h6>
+<h6 id="_short_description_79">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
@@ -5075,7 +5105,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_76">Short description</h6>
+<h6 id="_short_description_80">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link sensor as a raw byte array. Might be useful for testing.</p>
 </div>
@@ -5164,7 +5194,7 @@ NUM will be replaced by the number of instance (e.g. "writeIODDMessage1").</p>
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_77">Short description</h6>
+<h6 id="_short_description_81">Short description</h6>
 <div class="paragraph">
 <p>Write parameter as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -5257,7 +5287,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterByteArrayUI"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterByteArrayUI()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_78">Short description</h6>
+<h6 id="_short_description_82">Short description</h6>
 <div class="paragraph">
 <p>Write parameter to IO-Link device as a raw byte array triggered by button in UI.</p>
 </div>
@@ -5274,7 +5304,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterByteArray_1"
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_79">Short description</h6>
+<h6 id="_short_description_83">Short description</h6>
 <div class="paragraph">
 <p>Write parameter with provided info from IODD interpreter and data to write (as JSON tables).<br>
 NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p>
@@ -5370,7 +5400,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeParameterRowSelectedCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeParameterRowSelectedCSKIODDInterpreter()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_80">Short description</h6>
+<h6 id="_short_description_84">Short description</h6>
 <div class="paragraph">
 <p>Function to call  CSK_IODDInterpreter.writeParameterRowSelected function when row in write parameters table of write message is selected.</p>
 </div>
@@ -5414,7 +5444,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessData"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessData()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_81">Short description</h6>
+<h6 id="_short_description_85">Short description</h6>
 <div class="paragraph">
 <p>Write process data to IO-Link sensor in case the IODD description of the parameter is available.</p>
 </div>
@@ -5485,7 +5515,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataByteArray()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_82">Short description</h6>
+<h6 id="_short_description_86">Short description</h6>
 <div class="paragraph">
 <p>Write process data to IO-Link sensor as a raw byte array. Might be useful for testing.</p>
 </div>
@@ -5562,7 +5592,7 @@ NUM will be replaced by the number of instance (e.g. "writeParameterIODD_1").</p
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataByteArray_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataByteArray_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_83">Short description</h6>
+<h6 id="_short_description_87">Short description</h6>
 <div class="paragraph">
 <p>Write process data as byte array in IO-Link JSON standard, for example:<br>
 {<br>
@@ -5654,7 +5684,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataByteArray_
 <div class="sect4">
 <h5 id="API:Function:CSK_MultiIOLinkSMI.writeProcessDataIODD_NUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-function">writeProcessDataIODD_NUM()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_84">Short description</h6>
+<h6 id="_short_description_88">Short description</h6>
 <div class="paragraph">
 <p>Write process data with provided info from IODD interpreter and data to write (as JSON tables).<br>
 NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").</p>
@@ -5741,7 +5771,7 @@ NUM will be replaced by the number of instance (e.g. "writeProcessDataIODD_1").<
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnDataLoadedOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnDataLoadedOnReboot</span></h5>
 <div class="sect5">
-<h6 id="_short_description_85">Short description</h6>
+<h6 id="_short_description_89">Short description</h6>
 <div class="paragraph">
 <p>Event to call if module tried to load parameters and should be ready.</p>
 </div>
@@ -5761,6 +5791,12 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceId</span></h5>
+<div class="sect5">
+<h6 id="_short_description_90">Short description</h6>
+<div class="paragraph">
+<p>Event to show the device ID of the device.</p>
+</div>
+</div>
 <div class="sect5">
 <h6 id="_callback_arguments">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
@@ -5783,7 +5819,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <td class="tableblock halign-left valign-top"><p class="tableblock">deviceId</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Device ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -5804,7 +5840,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewDeviceIdentificationApplied"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewDeviceIdentificationApplied</span></h5>
 <div class="sect5">
-<h6 id="_short_description_86">Short description</h6>
+<h6 id="_short_description_91">Short description</h6>
 <div class="paragraph">
 <p>Notify if device identification of new discovered device is applied instead of the old one.</p>
 </div>
@@ -5858,7 +5894,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewFirmwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_87">Short description</h6>
+<h6 id="_short_description_92">Short description</h6>
 <div class="paragraph">
 <p>Event to show the firmware version of the device.</p>
 </div>
@@ -5906,7 +5942,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewHardwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_88">Short description</h6>
+<h6 id="_short_description_93">Short description</h6>
 <div class="paragraph">
 <p>Event to show the hardware version of the device.</p>
 </div>
@@ -5954,7 +5990,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewInstanceList"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewInstanceList</span></h5>
 <div class="sect5">
-<h6 id="_short_description_89">Short description</h6>
+<h6 id="_short_description_94">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created instances</p>
 </div>
@@ -6002,7 +6038,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewIOLinkPortStatus"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewIOLinkPortStatus</span></h5>
 <div class="sect5">
-<h6 id="_short_description_90">Short description</h6>
+<h6 id="_short_description_95">Short description</h6>
 <div class="paragraph">
 <p>Notify new status of the IO-Link port.</p>
 </div>
@@ -6056,7 +6092,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListIODDReadMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDReadMessages</span></h5>
 <div class="sect5">
-<h6 id="_short_description_91">Short description</h6>
+<h6 id="_short_description_96">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created read messages.</p>
 </div>
@@ -6104,7 +6140,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListIODDWriteMessages"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListIODDWriteMessages</span></h5>
 <div class="sect5">
-<h6 id="_short_description_92">Short description</h6>
+<h6 id="_short_description_97">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of created write messages.</p>
 </div>
@@ -6152,7 +6188,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewListProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewListProcessDataCondition</span></h5>
 <div class="sect5">
-<h6 id="_short_description_93">Short description</h6>
+<h6 id="_short_description_98">Short description</h6>
 <div class="paragraph">
 <p>Event to provide list of process data structure options.</p>
 </div>
@@ -6200,6 +6236,12 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceDeviceId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceDeviceId</span></h5>
 <div class="sect5">
+<h6 id="_short_description_99">Short description</h6>
+<div class="paragraph">
+<p>Event to show the device ID of new discovered device.</p>
+</div>
+</div>
+<div class="sect5">
 <h6 id="_callback_arguments_10">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -6221,7 +6263,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <td class="tableblock halign-left valign-top"><p class="tableblock">deviceId</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Device ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -6242,7 +6284,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceFirmwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceFirmwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_94">Short description</h6>
+<h6 id="_short_description_100">Short description</h6>
 <div class="paragraph">
 <p>Event to show the firmware version of new discovered device.</p>
 </div>
@@ -6290,7 +6332,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceHardwareVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceHardwareVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_95">Short description</h6>
+<h6 id="_short_description_101">Short description</h6>
 <div class="paragraph">
 <p>Event to show the hardware version of new discovered device.</p>
 </div>
@@ -6338,7 +6380,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_96">Short description</h6>
+<h6 id="_short_description_102">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product id of new discovered device.</p>
 </div>
@@ -6386,7 +6428,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_97">Short description</h6>
+<h6 id="_short_description_103">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product name of new discovered device.</p>
 </div>
@@ -6434,7 +6476,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceProductText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceProductText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_98">Short description</h6>
+<h6 id="_short_description_104">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product text of new discovered device.</p>
 </div>
@@ -6482,7 +6524,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceSerialNumber"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceSerialNumber</span></h5>
 <div class="sect5">
-<h6 id="_short_description_99">Short description</h6>
+<h6 id="_short_description_105">Short description</h6>
 <div class="paragraph">
 <p>Event to show the serial number of new discovered device.</p>
 </div>
@@ -6530,7 +6572,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_100">Short description</h6>
+<h6 id="_short_description_106">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor ID of new discovered device.</p>
 </div>
@@ -6578,7 +6620,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_101">Short description</h6>
+<h6 id="_short_description_107">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor name of new discovered device.</p>
 </div>
@@ -6626,7 +6668,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewNewDeviceVendorText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewNewDeviceVendorText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_102">Short description</h6>
+<h6 id="_short_description_108">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor text of new discovered device.</p>
 </div>
@@ -6674,7 +6716,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewParameterName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewParameterName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_103">Short description</h6>
+<h6 id="_short_description_109">Short description</h6>
 <div class="paragraph">
 <p>Notify name of persistent data parameter.</p>
 </div>
@@ -6722,7 +6764,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPort"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPort</span></h5>
 <div class="sect5">
-<h6 id="_short_description_104">Short description</h6>
+<h6 id="_short_description_110">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected IO-Link port in UI.</p>
 </div>
@@ -6770,7 +6812,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortDropdown"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortDropdown</span></h5>
 <div class="sect5">
-<h6 id="_short_description_105">Short description</h6>
+<h6 id="_short_description_111">Short description</h6>
 <div class="paragraph">
 <p>Event to show list of ports in UI.</p>
 </div>
@@ -6818,7 +6860,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortEvent"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortEvent</span></h5>
 <div class="sect5">
-<h6 id="_short_description_106">Short description</h6>
+<h6 id="_short_description_112">Short description</h6>
 <div class="paragraph">
 <p>Event to show the new status of active IO-Link port. Can be used externally.</p>
 </div>
@@ -6880,6 +6922,12 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortInformation"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortInformation</span></h5>
 <div class="sect5">
+<h6 id="_short_description_113">Short description</h6>
+<div class="paragraph">
+<p>Event triggerd when port status has changed which might mean that the IOLink device was connected/disconnected or another devices was connected.</p>
+</div>
+</div>
+<div class="sect5">
 <h6 id="_callback_arguments_24">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -6901,37 +6949,37 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <td class="tableblock halign-left valign-top"><p class="tableblock">instanceId</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">INT</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Instance ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portNumber</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Port name like S1, S2 &#8230;&#8203;</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portStatus</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">New port status.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonDeviceIdentification</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JSON object containing the saved device identification for this port.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ioddName</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">IODD name of an IODD object used in CSK_Module_IODDInterpreter for this instance.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonNewDeviceIdentification</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional JSON object with the device identification of the connected device if its ID does not match the saved one for this instance.</p></td>
 </tr>
 </tbody>
 </table>
@@ -6952,7 +7000,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewPortStatus"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewPortStatus</span></h5>
 <div class="sect5">
-<h6 id="_short_description_107">Short description</h6>
+<h6 id="_short_description_114">Short description</h6>
 <div class="paragraph">
 <p>Event to show current port status of selected IO-Link port in UI.</p>
 </div>
@@ -7000,7 +7048,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataCondition"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataCondition</span></h5>
 <div class="sect5">
-<h6 id="_short_description_108">Short description</h6>
+<h6 id="_short_description_115">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected IO-Link procecss data option of connected device in UI.</p>
 </div>
@@ -7048,7 +7096,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataInTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataInTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_109">Short description</h6>
+<h6 id="_short_description_116">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewProcessDataInTableContent event to fill the process data in table of the read message.</p>
 </div>
@@ -7096,7 +7144,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessDataOutTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessDataOutTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_110">Short description</h6>
+<h6 id="_short_description_117">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewProcessDataOutTableContent event to fill the process data out table of the write message.</p>
 </div>
@@ -7144,7 +7192,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProcessingParameter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProcessingParameter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_111">Short description</h6>
+<h6 id="_short_description_118">Short description</h6>
 <div class="paragraph">
 <p>Event to share processing parameters to the instances.</p>
 </div>
@@ -7210,7 +7258,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_112">Short description</h6>
+<h6 id="_short_description_119">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product id of connected IO-Link device.</p>
 </div>
@@ -7258,7 +7306,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_113">Short description</h6>
+<h6 id="_short_description_120">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product name of connected IO-Link device.</p>
 </div>
@@ -7306,7 +7354,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewProductText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewProductText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_114">Short description</h6>
+<h6 id="_short_description_121">Short description</h6>
 <div class="paragraph">
 <p>Event to show the product text of connected IO-Link device.</p>
 </div>
@@ -7354,7 +7402,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadDataMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_115">Short description</h6>
+<h6 id="_short_description_122">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received message after the refresh button has been pressed in UI.</p>
 </div>
@@ -7402,7 +7450,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadDataSuccess"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadDataSuccess</span></h5>
 <div class="sect5">
-<h6 id="_short_description_116">Short description</h6>
+<h6 id="_short_description_123">Short description</h6>
 <div class="paragraph">
 <p>Event to show the success of reading message after the refresh button has been pressed in UI.</p>
 </div>
@@ -7450,7 +7498,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadJSONTemplate</span></h5>
 <div class="sect5">
-<h6 id="_short_description_117">Short description</h6>
+<h6 id="_short_description_124">Short description</h6>
 <div class="paragraph">
 <p>Event to show JSON template of configured reading message.</p>
 </div>
@@ -7498,7 +7546,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadMessageEventName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadMessageEventName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_118">Short description</h6>
+<h6 id="_short_description_125">Short description</h6>
 <div class="paragraph">
 <p>Event to show the event name that can be used externally.</p>
 </div>
@@ -7546,7 +7594,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadParameterByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadParameterByteArray</span></h5>
 <div class="sect5">
-<h6 id="_short_description_119">Short description</h6>
+<h6 id="_short_description_126">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received byte array after reading the configured parameter from IO-Link device for testing purposes.</p>
 </div>
@@ -7594,7 +7642,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadParametersTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadParametersTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_120">Short description</h6>
+<h6 id="_short_description_127">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewReadParametersTableContent event to fill the paramters table of the read message.</p>
 </div>
@@ -7642,7 +7690,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewReadProcessDataByteArray"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewReadProcessDataByteArray</span></h5>
 <div class="sect5">
-<h6 id="_short_description_121">Short description</h6>
+<h6 id="_short_description_128">Short description</h6>
 <div class="paragraph">
 <p>Event to show the received byte array after reading the process data from IO-Link device for testing purposes.</p>
 </div>
@@ -7690,7 +7738,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewResultNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewResultNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_122">Short description</h6>
+<h6 id="_short_description_129">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to provide result of instance.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewResult1").<br>
@@ -7740,7 +7788,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedInstance"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedInstance</span></h5>
 <div class="sect5">
-<h6 id="_short_description_123">Short description</h6>
+<h6 id="_short_description_130">Short description</h6>
 <div class="paragraph">
 <p>Notify if new instance is selected.</p>
 </div>
@@ -7788,7 +7836,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedIODDReadMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedIODDReadMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_124">Short description</h6>
+<h6 id="_short_description_131">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected read message.</p>
 </div>
@@ -7836,7 +7884,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedIODDWriteMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedIODDWriteMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_125">Short description</h6>
+<h6 id="_short_description_132">Short description</h6>
 <div class="paragraph">
 <p>Event to show selected write message.</p>
 </div>
@@ -7884,7 +7932,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSelectedTab"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSelectedTab</span></h5>
 <div class="sect5">
-<h6 id="_short_description_126">Short description</h6>
+<h6 id="_short_description_133">Short description</h6>
 <div class="paragraph">
 <p>Notify to show selected tab.</p>
 </div>
@@ -7932,7 +7980,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewSerialNumber"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewSerialNumber</span></h5>
 <div class="sect5">
-<h6 id="_short_description_127">Short description</h6>
+<h6 id="_short_description_134">Short description</h6>
 <div class="paragraph">
 <p>Event to show the serial number of connected IO-Link device.</p>
 </div>
@@ -7980,7 +8028,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusCSKIODDInterpreterAvailable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusCSKIODDInterpreterAvailable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_128">Short description</h6>
+<h6 id="_short_description_135">Short description</h6>
 <div class="paragraph">
 <p>Event to show if there is available CSK IODD interpreter in the project.</p>
 </div>
@@ -8028,7 +8076,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusCSKStyle"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusCSKStyle</span></h5>
 <div class="sect5">
-<h6 id="_short_description_129">Short description</h6>
+<h6 id="_short_description_136">Short description</h6>
 <div class="paragraph">
 <p>Notify UI style to use for CSK modules.</p>
 </div>
@@ -8076,7 +8124,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusFlowConfigPriority"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusFlowConfigPriority</span></h5>
 <div class="sect5">
-<h6 id="_short_description_130">Short description</h6>
+<h6 id="_short_description_137">Short description</h6>
 <div class="paragraph">
 <p>Notify if FlowConfig should have priority for FlowConfig relevant configurations.</p>
 </div>
@@ -8124,7 +8172,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusInstanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusInstanceActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_131">Short description</h6>
+<h6 id="_short_description_138">Short description</h6>
 <div class="paragraph">
 <p>Notify if instance is activated.</p>
 </div>
@@ -8172,7 +8220,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDMatchFound"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDMatchFound</span></h5>
 <div class="sect5">
-<h6 id="_short_description_132">Short description</h6>
+<h6 id="_short_description_139">Short description</h6>
 <div class="paragraph">
 <p>Event to notify if there is a matching IODD file found by IODD interpreter module.</p>
 </div>
@@ -8220,7 +8268,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDReadMessageSelected"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDReadMessageSelected</span></h5>
 <div class="sect5">
-<h6 id="_short_description_133">Short description</h6>
+<h6 id="_short_description_140">Short description</h6>
 <div class="paragraph">
 <p>Event to inform if the read message is selected in UI. Used to show settings in UI.</p>
 </div>
@@ -8268,7 +8316,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusIODDWriteMessageSelected"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusIODDWriteMessageSelected</span></h5>
 <div class="sect5">
-<h6 id="_short_description_134">Short description</h6>
+<h6 id="_short_description_141">Short description</h6>
 <div class="paragraph">
 <p>Event to inform if the write message is selected in UI. Used to show settings in UI.</p>
 </div>
@@ -8316,7 +8364,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusLoadParameterOnReboot"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusLoadParameterOnReboot</span></h5>
 <div class="sect5">
-<h6 id="_short_description_135">Short description</h6>
+<h6 id="_short_description_142">Short description</h6>
 <div class="paragraph">
 <p>Notify status if parameters should be loaded on app-/device- boot up.</p>
 </div>
@@ -8364,7 +8412,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusModuleIsActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusModuleIsActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_136">Short description</h6>
+<h6 id="_short_description_143">Short description</h6>
 <div class="paragraph">
 <p>Notify if module can be used on device.</p>
 </div>
@@ -8412,7 +8460,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusModuleVersion"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusModuleVersion</span></h5>
 <div class="sect5">
-<h6 id="_short_description_137">Short description</h6>
+<h6 id="_short_description_144">Short description</h6>
 <div class="paragraph">
 <p>Notify version of module.</p>
 </div>
@@ -8460,7 +8508,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusNewDeviceFound"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusNewDeviceFound</span></h5>
 <div class="sect5">
-<h6 id="_short_description_138">Short description</h6>
+<h6 id="_short_description_145">Short description</h6>
 <div class="paragraph">
 <p>Event to notify if there is a new device discovered on selected port. Used to show settings in UI.</p>
 </div>
@@ -8508,7 +8556,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewStatusProcessDataVariable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewStatusProcessDataVariable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_139">Short description</h6>
+<h6 id="_short_description_146">Short description</h6>
 <div class="paragraph">
 <p>Event to show additional settings if process data of the IO-Link device has a variable structure.</p>
 </div>
@@ -8556,7 +8604,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTestCommandState"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTestCommandState</span></h5>
 <div class="sect5">
-<h6 id="_short_description_140">Short description</h6>
+<h6 id="_short_description_147">Short description</h6>
 <div class="paragraph">
 <p>Event to show latest status of reading or writing raw byte arrays from/to IO-Link device for testing purpuses.</p>
 </div>
@@ -8604,7 +8652,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTestWriteIODDMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTestWriteIODDMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_141">Short description</h6>
+<h6 id="_short_description_148">Short description</h6>
 <div class="paragraph">
 <p>Event to show the edited JSON payload of write message be sent to IO-Link device for testing purposes.</p>
 </div>
@@ -8652,7 +8700,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTriggerType"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTriggerType</span></h5>
 <div class="sect5">
-<h6 id="_short_description_142">Short description</h6>
+<h6 id="_short_description_149">Short description</h6>
 <div class="paragraph">
 <p>Event to show the selected trigger type of selected read message.</p>
 </div>
@@ -8700,7 +8748,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewTriggerValue"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewTriggerValue</span></h5>
 <div class="sect5">
-<h6 id="_short_description_143">Short description</h6>
+<h6 id="_short_description_150">Short description</h6>
 <div class="paragraph">
 <p>Event to show the selected trigger value of selected read message.</p>
 </div>
@@ -8748,7 +8796,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewValueToForwardNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewValueToForwardNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_144">Short description</h6>
+<h6 id="_short_description_151">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to forward data from instance thread to Controller part of module, e.g. to forward values to UI.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewValueToForward1").<br></p>
@@ -8803,7 +8851,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewValueUpdateNUM"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewValueUpdateNUM</span></h5>
 <div class="sect5">
-<h6 id="_short_description_145">Short description</h6>
+<h6 id="_short_description_152">Short description</h6>
 <div class="paragraph">
 <p>Example of dynamically created event to sync paramters between instance threads and Controller part of module.<br>
 NUM will be replaced by the number of instance (e.g. "OnNewResult1").<br></p>
@@ -8870,7 +8918,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorId"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorId</span></h5>
 <div class="sect5">
-<h6 id="_short_description_146">Short description</h6>
+<h6 id="_short_description_153">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor ID of connected IO-Link device.</p>
 </div>
@@ -8918,7 +8966,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_147">Short description</h6>
+<h6 id="_short_description_154">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor name of connected IO-Link device.</p>
 </div>
@@ -8966,7 +9014,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewVendorText"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewVendorText</span></h5>
 <div class="sect5">
-<h6 id="_short_description_148">Short description</h6>
+<h6 id="_short_description_155">Short description</h6>
 <div class="paragraph">
 <p>Event to show the vendor text of connected IO-Link device.</p>
 </div>
@@ -9014,7 +9062,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteDataMessage"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteDataMessage</span></h5>
 <div class="sect5">
-<h6 id="_short_description_149">Short description</h6>
+<h6 id="_short_description_156">Short description</h6>
 <div class="paragraph">
 <p>Event to show the latest payload of write message sent to IO-Link device after refresh button has been pressed.</p>
 </div>
@@ -9062,7 +9110,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteDataSuccess"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteDataSuccess</span></h5>
 <div class="sect5">
-<h6 id="_short_description_150">Short description</h6>
+<h6 id="_short_description_157">Short description</h6>
 <div class="paragraph">
 <p>Event to show the latest success of writing message to IO-Link device after refresh button has been pressed.</p>
 </div>
@@ -9110,7 +9158,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteJSONTemplate"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteJSONTemplate</span></h5>
 <div class="sect5">
-<h6 id="_short_description_151">Short description</h6>
+<h6 id="_short_description_158">Short description</h6>
 <div class="paragraph">
 <p>Event to show JSON template of configured write message.</p>
 </div>
@@ -9158,7 +9206,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteMessageFunctionName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteMessageFunctionName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_152">Short description</h6>
+<h6 id="_short_description_159">Short description</h6>
 <div class="paragraph">
 <p>Event to notify the name of the write data function that can be used externally.</p>
 </div>
@@ -9206,7 +9254,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnNewWriteParametersTableContentCSKIODDInterpreter"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnNewWriteParametersTableContentCSKIODDInterpreter</span></h5>
 <div class="sect5">
-<h6 id="_short_description_153">Short description</h6>
+<h6 id="_short_description_160">Short description</h6>
 <div class="paragraph">
 <p>Event to forward data from CSK_IODDInterpreter.OnNewWriteParametersTableContent event to fill the parameter table of the write message.</p>
 </div>
@@ -9254,7 +9302,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnPersistentDataModuleAvailable"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnPersistentDataModuleAvailable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_154">Short description</h6>
+<h6 id="_short_description_161">Short description</h6>
 <div class="paragraph">
 <p>Notify status if features of CSK_PersistentData module are available.</p>
 </div>
@@ -9302,7 +9350,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelAdminActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelAdminActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_155">Short description</h6>
+<h6 id="_short_description_162">Short description</h6>
 <div class="paragraph">
 <p>Status of Admin userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
@@ -9350,7 +9398,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelMaintenanceActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_156">Short description</h6>
+<h6 id="_short_description_163">Short description</h6>
 <div class="paragraph">
 <p>Status of Maintenance userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
@@ -9398,7 +9446,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelOperatorActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_157">Short description</h6>
+<h6 id="_short_description_164">Short description</h6>
 <div class="paragraph">
 <p>Status of Operator userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
@@ -9446,7 +9494,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.OnUserLevelServiceActive"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">OnUserLevelServiceActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_158">Short description</h6>
+<h6 id="_short_description_165">Short description</h6>
 <div class="paragraph">
 <p>Status of Service userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
@@ -9494,7 +9542,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_MultiIOLinkSMI.readMessagePortMessageName"><span class="breadcrumb">CSK_MultiIOLinkSMI.</span><span class="api-event">readMessagePortMessageName</span></h5>
 <div class="sect5">
-<h6 id="_short_description_159">Short description</h6>
+<h6 id="_short_description_166">Short description</h6>
 <div class="paragraph">
 <p>Event that can be used to get the message with data received from IOLink device. Port - sensor port the device is connected to (S1,S2 &#8230;&#8203;). MessageName - the configured name of the message.</p>
 </div>
@@ -9568,7 +9616,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect2">
 <h3 id="API:Crown:MultiIOLinkSMI_FC"><span class="api-crown">MultiIOLinkSMI_FC</span></h3>
 <div class="sect3">
-<h4 id="_short_description_160">Short description</h4>
+<h4 id="_short_description_167">Short description</h4>
 <div class="paragraph">
 <p>Crown to provide CSK_FlowConfig relevant features.</p>
 </div>
@@ -9581,7 +9629,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect2">
 <h3 id="API:Crown:MultiIOLinkSMI_FC.OnNewData"><span class="api-crown">MultiIOLinkSMI_FC.OnNewData</span></h3>
 <div class="sect3">
-<h4 id="_short_description_161">Short description</h4>
+<h4 id="_short_description_168">Short description</h4>
 <div class="admonitionblock important">
 <table>
 <tr>
@@ -9617,7 +9665,7 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Function:MultiIOLinkSMI_FC.OnNewData.create"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-function">create()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_162">Short description</h6>
+<h6 id="_short_description_169">Short description</h6>
 <div class="paragraph">
 <p>Internally used CSK_FlowConfig create function.</p>
 </div>
@@ -9694,7 +9742,7 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Function:MultiIOLinkSMI_FC.OnNewData.register"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-function">register()</span></h5>
 <div class="sect5">
-<h6 id="_short_description_163">Short description</h6>
+<h6 id="_short_description_170">Short description</h6>
 <div class="paragraph">
 <p>Internally used CSK_FlowConfig register function.</p>
 </div>
@@ -9780,7 +9828,7 @@ Provide IOLink data via event.
 <div class="sect4">
 <h5 id="API:Event:MultiIOLinkSMI_FC.OnNewData.OnNewData"><span class="breadcrumb">MultiIOLinkSMI_FC.OnNewData.</span><span class="api-event">OnNewData</span></h5>
 <div class="sect5">
-<h6 id="_short_description_164">Short description</h6>
+<h6 id="_short_description_171">Short description</h6>
 <div class="admonitionblock important">
 <table>
 <tr>
@@ -9855,7 +9903,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 2.0.0<br>
-Last updated 2024-10-21 09:54:47 +0200
+Last updated 2024-10-21 12:15:05 +0200
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 2.0.0

## Improvements

### Send parameters function tries to send only IODD instances of IODD module that are relevant only for the selected IOLinkSMI CSK instance

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
